### PR TITLE
feat: enable google ads with csp

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Hind+Siliguri:wght@300;400;500;600;700&display=swap">
     
     <!-- Google AdSense -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6185927994614530" crossorigin="anonymous"></script>
+    <script nonce="google-adsense" async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6185927994614530&host=ca-host-pub-6185927994614530" crossorigin="anonymous"></script>
     
     <!-- Structured Data for SEO -->
     <script type="application/ld+json">

--- a/src/components/GoogleAd.tsx
+++ b/src/components/GoogleAd.tsx
@@ -30,14 +30,21 @@ const GoogleAd: React.FC<GoogleAdProps> = ({
 
   return (
     <div className={`google-ad ${className}`} ref={adRef}>
-      <ins 
+      <ins
         className="adsbygoogle"
         style={{ display: 'block' }}
         data-ad-client="ca-pub-6185927994614530"
+        data-ad-host="ca-host-pub-6185927994614530"
         data-ad-slot={slot}
         data-ad-format={format}
         data-full-width-responsive={responsive ? 'true' : 'false'}
       ></ins>
+      <script
+        nonce="google-adsense"
+        dangerouslySetInnerHTML={{
+          __html: `(adsbygoogle = window.adsbygoogle || []).push({});`,
+        }}
+      />
     </div>
   );
 };

--- a/src/components/SecurityHeaders.tsx
+++ b/src/components/SecurityHeaders.tsx
@@ -9,10 +9,13 @@ const SecurityHeaders: React.FC = () => {
         httpEquiv="Content-Security-Policy" 
         content={`
           default-src 'self';
-          script-src 'self' 'unsafe-inline' 'unsafe-eval' 
-            https://pagead2.googlesyndication.com 
-            https://www.googletagmanager.com 
+          script-src 'self' 'unsafe-inline' 'unsafe-eval' 'nonce-google-adsense'
+            https://pagead2.googlesyndication.com
+            https://www.googletagmanager.com
             https://www.google-analytics.com
+            https://googleads.g.doubleclick.net
+            https://tpc.googlesyndication.com
+            https://adservice.google.com
             https://syndication.realsrv.com
             https://inklinkor.com
             https://www.topcreativeformat.com
@@ -23,20 +26,27 @@ const SecurityHeaders: React.FC = () => {
           font-src 'self' 
             https://fonts.gstatic.com 
             https://fonts.googleapis.com;
-          img-src 'self' data: blob: 
+          img-src 'self' data: blob:
             https://pagead2.googlesyndication.com
             https://www.google-analytics.com
             https://googleads.g.doubleclick.net
+            https://tpc.googlesyndication.com
+            https://adservice.google.com
             https://syndication.realsrv.com;
-          connect-src 'self' 
+          connect-src 'self'
             https://pagead2.googlesyndication.com
             https://www.google-analytics.com
+            https://googleads.g.doubleclick.net
+            https://tpc.googlesyndication.com
+            https://adservice.google.com
             https://syndication.realsrv.com
             https://medium.com
             https://api.medium.com;
-          frame-src 'self' 
+          frame-src 'self'
             https://pagead2.googlesyndication.com
             https://googleads.g.doubleclick.net
+            https://tpc.googlesyndication.com
+            https://adservice.google.com
             https://syndication.realsrv.com;
           object-src 'none';
           base-uri 'self';


### PR DESCRIPTION
## Summary
- load Google AdSense with nonce and host ID
- add ad host and initialization script to GoogleAd component
- widen Content Security Policy for Google ad domains

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 19 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c77138561483269e930c458e3d286a