### PR TITLE
fix: ensure JS assets served with correct MIME type

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/assets/*.js
+  Content-Type: application/javascript; charset=utf-8


### PR DESCRIPTION
## Summary
- add Cloudflare headers so JS files use `application/javascript`

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68c78811b2a883268b816196f95697c6