### PR TITLE
chore: verify Cloudflare deployment via workflow

### DIFF
--- a/.github/workflows/check-cloudflare.yml
+++ b/.github/workflows/check-cloudflare.yml
@@ -1,0 +1,26 @@
+name: Check Cloudflare Deployment
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check-cloudflare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Cloudflare deployment
+        run: |
+          set -e
+          HEADERS=$(curl -I -s https://prompt-panda.pages.dev)
+          echo "$HEADERS"
+          if ! echo "$HEADERS" | grep -i 'cf-ray'; then
+            echo "Cloudflare header not found" >&2
+            exit 1
+          fi
+          STATUS=$(echo "$HEADERS" | head -n 1 | awk '{print $2}')
+          if [ "$STATUS" != "200" ]; then
+            echo "Unexpected status: $STATUS" >&2
+            exit 1
+          fi
+          echo "Cloudflare deployment OK"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to check Cloudflare headers for prompt deployment

## Testing
- `yarn lint` *(fails: 14 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b6f7c7fc8326b87ff1de7547c0e6