### PR TITLE
Add community prompts features

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ const Index = React.lazy(() => import("./pages/Index"));
 const NotFound = React.lazy(() => import("./pages/NotFound"));
 const PrivacyPolicy = React.lazy(() => import("./pages/PrivacyPolicy"));
 const CookiePolicy = React.lazy(() => import("./pages/CookiePolicy"));
+const CommunityPrompts = React.lazy(() => import("./pages/Community/Prompts"));
+const SubmitPrompt = React.lazy(() => import("./pages/Community/SubmitPrompt"));
 
 // Initialize Google AdSense
 const adsLogger = createScopedLogger("adsense");
@@ -57,6 +59,8 @@ const App = () => {
                 <Route path="/" element={<Index />} />
                 <Route path="/privacy-policy" element={<PrivacyPolicy />} />
                 <Route path="/cookie-policy" element={<CookiePolicy />} />
+                <Route path="/community/prompts" element={<CommunityPrompts />} />
+                <Route path="/community/submit" element={<SubmitPrompt />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -25,6 +25,7 @@ const Navbar = () => {
     { name: "হোম", href: "#" },
     { name: "কোর্স", href: "#features" },
     { name: "রিসোর্স", href: "#resources" },
+    { name: "কমিউনিটি", href: "/community/prompts" },
     { name: "সম্পর্কে", href: "#about" },
   ];
 
@@ -61,10 +62,10 @@ const Navbar = () => {
 
           <div className="hidden md:flex items-center gap-4">
             <a
-              href="#contact"
+              href="/community/submit"
               className="px-5 py-2 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white font-medium transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 active:scale-[0.98]"
             >
-              শুরু করুন
+              কমিউনিটিতে যোগ দিন
             </a>
           </div>
 
@@ -99,11 +100,11 @@ const Navbar = () => {
                 </a>
               ))}
               <a
-                href="#contact"
+                href="/community/submit"
                 className="px-5 py-2 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white font-medium text-center transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 active:scale-[0.98]"
                 onClick={() => setMenuOpen(false)}
               >
-                শুরু করুন
+                কমিউনিটিতে যোগ দিন
               </a>
             </nav>
           </div>

--- a/src/components/PromptCard.tsx
+++ b/src/components/PromptCard.tsx
@@ -1,0 +1,388 @@
+import { useEffect, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { formatDistanceToNow } from "date-fns";
+import { bn } from "date-fns/locale";
+import { MessageCircle, Send, ThumbsUp, Loader2, Copy } from "lucide-react";
+import { toast } from "sonner";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { createScopedLogger } from "@/lib/logger";
+import { getStoredCommunityDisplayName, persistCommunityDisplayName } from "@/lib/community/profile";
+import { supabase } from "@/integrations/supabase/client";
+import { withCommunityIdentity } from "@/integrations/supabase/community";
+import type { CommunityPrompt, PromptComment } from "@/types/community";
+
+interface PromptCardProps {
+  prompt: CommunityPrompt;
+  identity: string | null;
+  identityReady: boolean;
+}
+
+const logger = createScopedLogger("prompt-card");
+const MAX_COMMENT_LENGTH = 500;
+
+const formatRelativeTime = (date: string) =>
+  formatDistanceToNow(new Date(date), { addSuffix: true, locale: bn });
+
+const PromptCard = ({ prompt, identity, identityReady }: PromptCardProps) => {
+  const queryClient = useQueryClient();
+
+  const [localUpvotes, setLocalUpvotes] = useState(prompt.upvote_count);
+  const [localComments, setLocalComments] = useState(prompt.comment_count);
+  const [userHasUpvoted, setUserHasUpvoted] = useState(prompt.user_has_upvoted);
+  const [isCommentsOpen, setIsCommentsOpen] = useState(false);
+  const [displayName, setDisplayName] = useState(getStoredCommunityDisplayName);
+  const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    setLocalUpvotes(prompt.upvote_count);
+    setLocalComments(prompt.comment_count);
+    setUserHasUpvoted(prompt.user_has_upvoted);
+  }, [prompt]);
+
+  const { data: comments, isLoading: isCommentsLoading, refetch: refetchComments } = useQuery({
+    queryKey: ["prompt-comments", prompt.id],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from("prompt_comments")
+        .select("id, prompt_id, author_name, content, created_at")
+        .eq("prompt_id", prompt.id)
+        .order("created_at", { ascending: true });
+
+      if (error) {
+        logger.error("Failed to fetch prompt comments", { error, promptId: prompt.id });
+        throw error;
+      }
+
+      return (data ?? []) as PromptComment[];
+    },
+    enabled: isCommentsOpen,
+    staleTime: 30_000,
+  });
+
+  const updatePromptCache = (updater: (current: CommunityPrompt) => CommunityPrompt) => {
+    queryClient.setQueryData<CommunityPrompt[] | undefined>(["community-prompts"], data => {
+      if (!data) {
+        return data;
+      }
+
+      return data.map(item => (item.id === prompt.id ? updater(item) : item));
+    });
+  };
+
+  const upvoteMutation = useMutation({
+    mutationFn: async () => {
+      if (!identityReady || !identity) {
+        throw new Error("identity-not-ready");
+      }
+
+      if (userHasUpvoted) {
+        const builder = withCommunityIdentity(supabase.from("prompt_upvotes"), identity);
+        const { error } = await builder
+          .delete()
+          .eq("prompt_id", prompt.id)
+          .eq("community_identity", identity);
+
+        if (error) {
+          throw error;
+        }
+
+        return false;
+      }
+
+      const { error } = await supabase
+        .from("prompt_upvotes")
+        .upsert(
+          [
+            {
+              prompt_id: prompt.id,
+              community_identity: identity,
+            },
+          ],
+          { onConflict: "prompt_id,community_identity" },
+        );
+
+      if (error) {
+        throw error;
+      }
+
+      return true;
+    },
+    onSuccess: async (hasUpvotedNow) => {
+      const nextCount = hasUpvotedNow
+        ? localUpvotes + 1
+        : Math.max(localUpvotes - 1, 0);
+
+      setLocalUpvotes(nextCount);
+      setUserHasUpvoted(hasUpvotedNow);
+
+      updatePromptCache(current => ({
+        ...current,
+        upvote_count: nextCount,
+        user_has_upvoted: hasUpvotedNow,
+      }));
+
+      await queryClient.invalidateQueries({ queryKey: ["community-prompts"] });
+    },
+    onError: error => {
+      if ((error as Error).message === "identity-not-ready") {
+        toast.info("কমিউনিটি প্রোফাইল প্রস্তুত হচ্ছে। একটু পর আবার চেষ্টা করুন।");
+        return;
+      }
+
+      logger.error("Failed to toggle upvote", { error, promptId: prompt.id });
+      toast.error("আপভোট করা যায়নি। পরে আবার চেষ্টা করুন।");
+    },
+  });
+
+  const commentMutation = useMutation({
+    mutationFn: async () => {
+      if (!identityReady || !identity) {
+        throw new Error("identity-not-ready");
+      }
+
+      const trimmed = comment.trim();
+      if (!trimmed) {
+        throw new Error("empty-comment");
+      }
+
+      const { error } = await supabase.from("prompt_comments").insert({
+        prompt_id: prompt.id,
+        community_identity: identity,
+        author_name: displayName.trim() || null,
+        content: trimmed,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: async () => {
+      setComment("");
+      const nextCount = localComments + 1;
+      setLocalComments(nextCount);
+
+      updatePromptCache(current => ({
+        ...current,
+        comment_count: nextCount,
+      }));
+
+      await queryClient.invalidateQueries({ queryKey: ["community-prompts"] });
+      await refetchComments();
+      toast.success("মন্তব্য যুক্ত হয়েছে!");
+    },
+    onError: error => {
+      const message = (error as Error).message;
+      if (message === "identity-not-ready") {
+        toast.info("কমিউনিটি প্রোফাইল প্রস্তুত হচ্ছে। একটু পর আবার চেষ্টা করুন।");
+        return;
+      }
+
+      if (message === "empty-comment") {
+        toast.warning("অনুগ্রহ করে আপনার মন্তব্য লিখুন।");
+        return;
+      }
+
+      logger.error("Failed to create comment", { error, promptId: prompt.id });
+      toast.error("মন্তব্য পাঠাতে সমস্যা হয়েছে। পরে আবার চেষ্টা করুন।");
+    },
+  });
+
+  const copyPrompt = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt.prompt);
+      toast.success("প্রম্পট কপি করা হয়েছে!");
+    } catch (error) {
+      logger.error("Failed to copy prompt to clipboard", { error, promptId: prompt.id });
+      toast.error("কপি করা যায়নি। আপনার ব্রাউজার অনুমতি দিচ্ছে কি না দেখুন।");
+    }
+  };
+
+  const promptTags = useMemo(() => prompt.tags.filter(Boolean), [prompt.tags]);
+
+  const upvoteDisabled = !identityReady || !identity || upvoteMutation.isPending;
+  const commentDisabled =
+    !identityReady || !identity || commentMutation.isPending || comment.trim().length === 0;
+
+  return (
+    <Card className="border-4 border-black shadow-lg bg-white">
+      <CardHeader className="space-y-3">
+        <div className="flex flex-wrap gap-3 items-start justify-between">
+          <CardTitle className="text-2xl font-display text-purple-600">
+            {prompt.title}
+          </CardTitle>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span className="font-bengali">
+              {prompt.submitter_name ? `${prompt.submitter_name} ✨` : "কমিউনিটি সদস্য"}
+            </span>
+            <span aria-hidden="true">•</span>
+            <span className="font-bengali">{formatRelativeTime(prompt.created_at)}</span>
+          </div>
+        </div>
+        {prompt.use_case && (
+          <p className="text-base font-bengali text-slate-700 bg-orange-100 border border-orange-300 px-3 py-2 rounded-lg inline-block">
+            {prompt.use_case}
+          </p>
+        )}
+        <p className="font-bengali text-lg text-slate-800 whitespace-pre-wrap leading-relaxed">
+          {prompt.prompt}
+        </p>
+        {prompt.description && (
+          <p className="font-bengali text-base text-muted-foreground bg-slate-100 border border-slate-200 px-3 py-2 rounded-lg">
+            {prompt.description}
+          </p>
+        )}
+        {promptTags.length > 0 && (
+          <div className="flex flex-wrap gap-2 pt-2">
+            {promptTags.map(tag => (
+              <Badge key={tag} variant="secondary" className="rounded-full border border-black/10">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardHeader>
+      <CardContent className="pt-0">
+        <div className="flex flex-wrap items-center justify-between gap-3 border border-dashed border-slate-200 rounded-xl px-4 py-3 bg-slate-50">
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant={userHasUpvoted ? "default" : "outline"}
+              onClick={() => upvoteMutation.mutate()}
+              disabled={upvoteDisabled}
+              className={cn(
+                "flex items-center gap-2 font-bengali",
+                userHasUpvoted ? "bg-purple-600 hover:bg-purple-700" : "",
+              )}
+            >
+              {upvoteMutation.isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ThumbsUp className="h-4 w-4" />
+              )}
+              <span>{userHasUpvoted ? "আপভোট হয়েছে" : "আপভোট"}</span>
+              <span className="font-semibold">{localUpvotes}</span>
+            </Button>
+            <Button
+              type="button"
+              variant={isCommentsOpen ? "default" : "outline"}
+              onClick={() => setIsCommentsOpen(value => !value)}
+              className="flex items-center gap-2 font-bengali"
+            >
+              <MessageCircle className="h-4 w-4" />
+              <span>মন্তব্য</span>
+              <span className="font-semibold">{localComments}</span>
+            </Button>
+          </div>
+          <div className="flex items-center gap-2">
+            {prompt.language && (
+              <Badge variant="outline" className="font-bengali border-2 border-black/20">
+                {prompt.language}
+              </Badge>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              className="flex items-center gap-2"
+              onClick={copyPrompt}
+            >
+              <Copy className="h-4 w-4" />
+              <span className="font-bengali">কপি</span>
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+      {isCommentsOpen && (
+        <CardFooter className="flex-col items-start gap-6">
+          <div className="w-full space-y-4">
+            <Separator className="bg-slate-200" />
+            <div className="space-y-3">
+              <h4 className="font-display text-lg">কমিউনিটি আলোচনা</h4>
+              {isCommentsLoading ? (
+                <div className="space-y-2">
+                  {Array.from({ length: 3 }).map((_, index) => (
+                    <Skeleton key={index} className="h-16 w-full rounded-lg" />
+                  ))}
+                </div>
+              ) : comments && comments.length > 0 ? (
+                <ul className="space-y-3">
+                  {comments.map(item => (
+                    <li
+                      key={item.id}
+                      className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3"
+                    >
+                      <div className="flex items-center justify-between text-sm text-muted-foreground">
+                        <span className="font-bengali">
+                          {item.author_name || "কমিউনিটি সদস্য"}
+                        </span>
+                        <span>{formatRelativeTime(item.created_at)}</span>
+                      </div>
+                      <p className="mt-2 text-slate-800 font-bengali leading-relaxed whitespace-pre-wrap">
+                        {item.content}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="text-sm text-muted-foreground font-bengali">
+                  এখনও কোনো মন্তব্য নেই। আপনি সবার আগে আপনার মতামত জানান!
+                </p>
+              )}
+            </div>
+          </div>
+
+          <form
+            className="w-full space-y-3 rounded-xl border-2 border-dashed border-purple-200 bg-purple-50 p-4"
+            onSubmit={event => {
+              event.preventDefault();
+              commentMutation.mutate();
+            }}
+          >
+            <h5 className="font-display text-lg text-purple-700">নিজের অভিজ্ঞতা শেয়ার করুন</h5>
+            <Input
+              value={displayName}
+              placeholder="আপনার নাম (ঐচ্ছিক)"
+              onChange={event => {
+                setDisplayName(event.target.value);
+                persistCommunityDisplayName(event.target.value);
+              }}
+              className="font-bengali"
+            />
+            <Textarea
+              value={comment}
+              onChange={event => {
+                if (event.target.value.length <= MAX_COMMENT_LENGTH) {
+                  setComment(event.target.value);
+                }
+              }}
+              placeholder="আপনার মন্তব্য লিখুন..."
+              rows={4}
+              maxLength={MAX_COMMENT_LENGTH}
+              className="font-bengali"
+            />
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>{comment.length}/{MAX_COMMENT_LENGTH}</span>
+              <Button type="submit" disabled={commentDisabled} className="flex items-center gap-2">
+                {commentMutation.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4" />
+                )}
+                <span className="font-bengali">মন্তব্য পাঠান</span>
+              </Button>
+            </div>
+          </form>
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default PromptCard;

--- a/src/hooks/useCommunityIdentity.ts
+++ b/src/hooks/useCommunityIdentity.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { createScopedLogger } from "@/lib/logger";
+
+const logger = createScopedLogger("community-identity");
+
+const STORAGE_KEY = "banglaprompt.community.identity";
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const generateIdentity = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  logger.warn("crypto.randomUUID unavailable, falling back to Math.random uuid");
+  const random = Math.random().toString(16).slice(2);
+  const timestamp = Date.now().toString(16);
+  return `${timestamp.slice(0, 8)}-${timestamp.slice(8, 12).padEnd(4, "0")}-${
+    random.slice(0, 4) || "abcd"
+  }-${random.slice(4, 8) || "ef00"}-${random.slice(8, 20).padEnd(12, "0")}`;
+};
+
+const readStoredIdentity = () => {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    if (stored && UUID_REGEX.test(stored)) {
+      return stored;
+    }
+  } catch (error) {
+    logger.error("Failed to read community identity from storage", { error });
+  }
+
+  return null;
+};
+
+const persistIdentity = (identity: string) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, identity);
+  } catch (error) {
+    logger.error("Failed to persist community identity", { error });
+  }
+};
+
+export const ensureCommunityIdentity = () => {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const stored = readStoredIdentity();
+  if (stored) {
+    return stored;
+  }
+
+  const identity = generateIdentity();
+  persistIdentity(identity);
+  return identity;
+};
+
+export const useCommunityIdentity = () => {
+  const [identity, setIdentity] = useState<string | null>(null);
+  const [isReady, setIsReady] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    try {
+      const value = ensureCommunityIdentity();
+      setIdentity(value);
+    } finally {
+      setIsReady(true);
+    }
+  }, []);
+
+  return { identity, isReady } as const;
+};
+

--- a/src/integrations/supabase/community.ts
+++ b/src/integrations/supabase/community.ts
@@ -1,0 +1,12 @@
+export const COMMUNITY_IDENTITY_HEADER = "x-community-identity";
+
+export const withCommunityIdentity = <T extends { headers: Headers }>(
+  builder: T,
+  identity?: string | null,
+): T => {
+  if (identity) {
+    builder.headers.set(COMMUNITY_IDENTITY_HEADER, identity);
+  }
+
+  return builder;
+};

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,124 @@ export type Database = {
   }
   public: {
     Tables: {
+      prompt_comments: {
+        Row: {
+          author_name: string | null
+          community_identity: string
+          content: string
+          created_at: string
+          id: string
+          prompt_id: string
+        }
+        Insert: {
+          author_name?: string | null
+          community_identity: string
+          content: string
+          created_at?: string
+          id?: string
+          prompt_id: string
+        }
+        Update: {
+          author_name?: string | null
+          community_identity?: string
+          content?: string
+          created_at?: string
+          id?: string
+          prompt_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompt_comments_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      prompt_upvotes: {
+        Row: {
+          community_identity: string
+          created_at: string
+          id: string
+          prompt_id: string
+        }
+        Insert: {
+          community_identity: string
+          created_at?: string
+          id?: string
+          prompt_id: string
+        }
+        Update: {
+          community_identity?: string
+          created_at?: string
+          id?: string
+          prompt_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompt_upvotes_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "prompts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      prompts: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          description: string | null
+          id: string
+          language: string | null
+          prompt: string
+          submitter_email: string | null
+          submitter_name: string | null
+          tags: string[]
+          title: string
+          updated_at: string
+          use_case: string | null
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          language?: string | null
+          prompt: string
+          submitter_email?: string | null
+          submitter_name?: string | null
+          tags?: string[]
+          title: string
+          updated_at?: string
+          use_case?: string | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          description?: string | null
+          id?: string
+          language?: string | null
+          prompt?: string
+          submitter_email?: string | null
+          submitter_name?: string | null
+          tags?: string[]
+          title?: string
+          updated_at?: string
+          use_case?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "prompts_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+            referencedSchema: "auth"
+          }
+        ]
+      }
       newsletter_subscriptions: {
         Row: {
           email: string

--- a/src/lib/community/profile.ts
+++ b/src/lib/community/profile.ts
@@ -1,0 +1,30 @@
+import { createScopedLogger } from "@/lib/logger";
+
+const logger = createScopedLogger("community-profile");
+
+const DISPLAY_NAME_STORAGE_KEY = "banglaprompt.community.display_name";
+
+export const getStoredCommunityDisplayName = () => {
+  if (typeof window === "undefined") {
+    return "";
+  }
+
+  try {
+    return window.localStorage.getItem(DISPLAY_NAME_STORAGE_KEY) ?? "";
+  } catch (error) {
+    logger.error("Unable to read stored community display name", { error });
+    return "";
+  }
+};
+
+export const persistCommunityDisplayName = (value: string) => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  try {
+    window.localStorage.setItem(DISPLAY_NAME_STORAGE_KEY, value);
+  } catch (error) {
+    logger.error("Unable to persist community display name", { error });
+  }
+};

--- a/src/pages/Community/Prompts.tsx
+++ b/src/pages/Community/Prompts.tsx
@@ -1,0 +1,270 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { Search, Sparkles, AlertTriangle } from "lucide-react";
+
+import SEOHead from "@/components/SEOHead";
+import PromptCard from "@/components/PromptCard";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useCommunityIdentity } from "@/hooks/useCommunityIdentity";
+import { supabase } from "@/integrations/supabase/client";
+import { createScopedLogger } from "@/lib/logger";
+import type { CommunityPrompt } from "@/types/community";
+
+const logger = createScopedLogger("community-prompts-page");
+
+const CommunityPrompts = () => {
+  const { identity, isReady } = useCommunityIdentity();
+  const [searchTerm, setSearchTerm] = useState("");
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedSearch(searchTerm.trim()), 300);
+    return () => window.clearTimeout(timeout);
+  }, [searchTerm]);
+
+  const identityKey = identity ?? "anon";
+
+  const { data: prompts, isLoading, isError, error } = useQuery({
+    queryKey: ["community-prompts", identityKey],
+    queryFn: async () => {
+      const { data, error: promptsError } = await supabase
+        .from("prompts")
+        .select(
+          `
+          id,
+          title,
+          prompt,
+          description,
+          use_case,
+          language,
+          tags,
+          submitter_name,
+          created_at,
+          prompt_upvotes(count),
+          prompt_comments(count)
+        `,
+        )
+        .order("created_at", { ascending: false });
+
+      if (promptsError) {
+        logger.error("Failed to load community prompts", { error: promptsError });
+        throw promptsError;
+      }
+
+      const mapped = (data ?? []).map((item) => {
+        const upvotesArray = Array.isArray(item.prompt_upvotes) ? item.prompt_upvotes : [];
+        const commentsArray = Array.isArray(item.prompt_comments) ? item.prompt_comments : [];
+
+        const promptData: CommunityPrompt = {
+          id: item.id,
+          title: item.title,
+          prompt: item.prompt,
+          description: item.description,
+          use_case: item.use_case,
+          language: item.language,
+          tags: item.tags ?? [],
+          submitter_name: item.submitter_name,
+          created_at: item.created_at,
+          upvote_count: upvotesArray[0]?.count ?? 0,
+          comment_count: commentsArray[0]?.count ?? 0,
+          user_has_upvoted: false,
+        };
+
+        return promptData;
+      });
+
+      if (!identity) {
+        return mapped;
+      }
+
+      const { data: upvotesData, error: upvotesError } = await supabase
+        .from("prompt_upvotes")
+        .select("prompt_id")
+        .eq("community_identity", identity);
+
+      if (upvotesError) {
+        logger.error("Failed to load current user upvotes", { error: upvotesError });
+        return mapped;
+      }
+
+      const upvotedIds = new Set((upvotesData ?? []).map((row) => row.prompt_id));
+
+      return mapped.map((item) => ({
+        ...item,
+        user_has_upvoted: upvotedIds.has(item.id),
+      }));
+    },
+    staleTime: 60_000,
+  });
+
+  const availableTags = useMemo(() => {
+    if (!prompts) {
+      return [] as string[];
+    }
+
+    const tagSet = new Set<string>();
+    prompts.forEach((promptItem) => {
+      promptItem.tags.forEach((tag) => {
+        if (tag) {
+          tagSet.add(tag);
+        }
+      });
+    });
+
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b));
+  }, [prompts]);
+
+  const filteredPrompts = useMemo(() => {
+    if (!prompts) {
+      return [] as CommunityPrompt[];
+    }
+
+    const term = debouncedSearch.toLowerCase();
+
+    return prompts.filter((promptItem) => {
+      const matchesTag = selectedTag ? promptItem.tags.includes(selectedTag) : true;
+
+      if (!term) {
+        return matchesTag;
+      }
+
+      const haystacks = [
+        promptItem.title,
+        promptItem.prompt,
+        promptItem.description ?? "",
+        promptItem.use_case ?? "",
+      ].map((value) => value.toLowerCase());
+
+      const matchesSearch = haystacks.some((value) => value.includes(term));
+
+      return matchesTag && matchesSearch;
+    });
+  }, [prompts, debouncedSearch, selectedTag]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-orange-50 to-rose-100">
+      <SEOHead
+        title="কমিউনিটি প্রম্পট লাইব্রেরি - প্রম্পট শিক্ষা"
+        description="বাংলা ভাষাভাষী কমিউনিটির তৈরি প্রম্পটগুলির সংগ্রহ। পছন্দের প্রম্পট আপভোট করুন এবং নিজের অভিজ্ঞতা শেয়ার করুন।"
+        url="https://promptshiksha.com/community/prompts"
+        keywords="বাংলা প্রম্পট, কমিউনিটি প্রম্পট, Prompt Library"
+      />
+
+      <div className="container mx-auto px-4 py-12">
+        <div className="text-center">
+          <div className="inline-flex items-center gap-3 rounded-full bg-white/80 px-5 py-2 text-sm font-bengali shadow">
+            <Sparkles className="h-4 w-4 text-purple-500" />
+            <span>বাংলা AI কমিউনিটির শেয়ার করা সেরা প্রম্পট</span>
+          </div>
+          <h1 className="mt-6 text-4xl font-display text-purple-700 md:text-5xl">
+            কমিউনিটি প্রম্পট লাইব্রেরি
+          </h1>
+          <p className="mt-4 max-w-2xl mx-auto font-bengali text-lg text-slate-700">
+            বাস্তব ব্যবহারকারীদের হাতে বানানো প্রম্পটগুলো খুঁজে বের করুন, নিজের মতামত জানান এবং নতুন আইডিয়া নিয়ে এক্সপেরিমেন্ট করুন।
+          </p>
+          <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+            <Button asChild variant="secondary" className="font-bengali">
+              <Link to="/community/submit">আপনার প্রম্পট শেয়ার করুন</Link>
+            </Button>
+            <Button asChild variant="link" className="font-bengali">
+              <Link to="/">হোমপেজে ফিরে যান</Link>
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-10 space-y-8">
+          <div className="cartoon-card bg-white p-6">
+            <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  value={searchTerm}
+                  onChange={(event) => setSearchTerm(event.target.value)}
+                  placeholder="প্রম্পট, ব্যবহার ক্ষেত্র বা লেখকের নাম দিয়ে সার্চ করুন"
+                  className="pl-9 font-bengali"
+                />
+              </div>
+              <Badge variant="outline" className="px-4 py-2 text-sm font-bengali">
+                মোট প্রম্পট: {prompts?.length ?? 0}
+              </Badge>
+            </div>
+
+            {availableTags.length > 0 && (
+              <div className="mt-6 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant={selectedTag ? "outline" : "default"}
+                  onClick={() => setSelectedTag(null)}
+                  className="rounded-full font-bengali"
+                >
+                  সব দেখুন
+                </Button>
+                {availableTags.map((tag) => (
+                  <Button
+                    key={tag}
+                    type="button"
+                    size="sm"
+                    variant={selectedTag === tag ? "default" : "outline"}
+                    onClick={() => setSelectedTag((current) => (current === tag ? null : tag))}
+                    className="rounded-full font-bengali"
+                  >
+                    #{tag}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {isError && (
+            <Alert variant="destructive" className="border-2 border-red-300">
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>ডেটা লোড করা যায়নি</AlertTitle>
+              <AlertDescription className="font-bengali">
+                {error instanceof Error
+                  ? error.message
+                  : "দুঃখিত! প্রম্পটগুলো এখন দেখানো যাচ্ছে না। পরে আবার চেষ্টা করুন।"}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {isLoading && (
+            <div className="grid gap-6">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={index} className="h-56 w-full rounded-3xl border-4 border-dashed border-slate-200" />
+              ))}
+            </div>
+          )}
+
+          {!isLoading && filteredPrompts.length === 0 && (
+            <div className="cartoon-card bg-white p-8 text-center">
+              <h2 className="text-2xl font-display text-purple-600">কোনো মিল পাওয়া যায়নি</h2>
+              <p className="mt-2 font-bengali text-slate-600">
+                আপনার অনুসন্ধানের সাথে মিলে এমন কোনো প্রম্পট পাওয়া যায়নি। অন্য কীওয়ার্ড ব্যবহার করে দেখুন অথবা ফিল্টার পরিবর্তন করুন।
+              </p>
+            </div>
+          )}
+
+          <div className="grid gap-6">
+            {filteredPrompts.map((promptItem) => (
+              <PromptCard
+                key={promptItem.id}
+                prompt={promptItem}
+                identity={identity}
+                identityReady={isReady}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CommunityPrompts;

--- a/src/pages/Community/SubmitPrompt.tsx
+++ b/src/pages/Community/SubmitPrompt.tsx
@@ -1,0 +1,353 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Sparkles, Lightbulb, PenSquare } from "lucide-react";
+import { toast } from "sonner";
+
+import SEOHead from "@/components/SEOHead";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { useCommunityIdentity } from "@/hooks/useCommunityIdentity";
+import { supabase } from "@/integrations/supabase/client";
+import { createScopedLogger } from "@/lib/logger";
+import { getStoredCommunityDisplayName, persistCommunityDisplayName } from "@/lib/community/profile";
+
+const logger = createScopedLogger("submit-community-prompt");
+
+const MAX_PROMPT_LENGTH = 2000;
+
+interface PromptFormState {
+  title: string;
+  prompt: string;
+  description: string;
+  use_case: string;
+  language: string;
+  tags: string;
+  submitter_name: string;
+  submitter_email: string;
+}
+
+const defaultFormState = (): PromptFormState => ({
+  title: "",
+  prompt: "",
+  description: "",
+  use_case: "",
+  language: "Bangla",
+  tags: "",
+  submitter_name: getStoredCommunityDisplayName(),
+  submitter_email: "",
+});
+
+const SubmitPrompt = () => {
+  const queryClient = useQueryClient();
+  const { isReady } = useCommunityIdentity();
+  const [formState, setFormState] = useState(defaultFormState);
+
+  const trimmedTitle = formState.title.trim();
+  const trimmedPrompt = formState.prompt.trim();
+  const trimmedDescription = formState.description.trim();
+  const trimmedUseCase = formState.use_case.trim();
+  const trimmedName = formState.submitter_name.trim();
+  const trimmedEmail = formState.submitter_email.trim();
+
+  const tagList = useMemo(
+    () =>
+      formState.tags
+        .split(",")
+        .map((tag) => tag.trim())
+        .filter(Boolean)
+        .slice(0, 8),
+    [formState.tags],
+  );
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!trimmedTitle) {
+        throw new Error("title-required");
+      }
+
+      if (trimmedPrompt.length < 20) {
+        throw new Error("prompt-too-short");
+      }
+
+      if (trimmedPrompt.length > MAX_PROMPT_LENGTH) {
+        throw new Error("prompt-too-long");
+      }
+
+      if (trimmedEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+        throw new Error("invalid-email");
+      }
+
+      const { error } = await supabase.from("prompts").insert({
+        title: trimmedTitle,
+        prompt: trimmedPrompt,
+        description: trimmedDescription || null,
+        use_case: trimmedUseCase || null,
+        language: formState.language || "Bangla",
+        tags: tagList,
+        submitter_name: trimmedName || null,
+        submitter_email: trimmedEmail || null,
+      });
+
+      if (error) {
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      toast.success("আপনার প্রম্পটটি সংরক্ষণ করা হয়েছে! যাচাইয়ের পর লাইব্রেরিতে যুক্ত হবে।");
+      persistCommunityDisplayName(trimmedName);
+      setFormState((current) => ({
+        ...defaultFormState(),
+        submitter_name: trimmedName,
+        submitter_email: trimmedEmail,
+      }));
+      queryClient.invalidateQueries({ queryKey: ["community-prompts"] });
+    },
+    onError: (error) => {
+      const message = error instanceof Error ? error.message : "unknown";
+
+      switch (message) {
+        case "title-required":
+          toast.warning("প্রম্পটের জন্য একটি শিরোনাম দিন।");
+          return;
+        case "prompt-too-short":
+          toast.warning("প্রম্পটটি আরও বিস্তারিতভাবে লিখুন (কমপক্ষে ২০ অক্ষর)।");
+          return;
+        case "prompt-too-long":
+          toast.warning(`প্রম্পটের দৈর্ঘ্য ${MAX_PROMPT_LENGTH} অক্ষরের মধ্যে রাখতে হবে।`);
+          return;
+        case "invalid-email":
+          toast.warning("সঠিক ইমেইল ঠিকানা লিখুন অথবা ফিল্ডটি ফাঁকা রাখুন।");
+          return;
+        default:
+          logger.error("Failed to submit community prompt", { error });
+          toast.error("দুঃখিত! প্রম্পট জমা দেয়া যায়নি। পরে আবার চেষ্টা করুন।");
+      }
+    },
+  });
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-white to-blue-100">
+      <SEOHead
+        title="কমিউনিটি প্রম্পট জমা দিন - প্রম্পট শিক্ষা"
+        description="আপনার প্রিয় বাংলা প্রম্পট শেয়ার করুন। কমিউনিটির সাথে নতুন আইডিয়া বিনিময় করুন এবং অনুপ্রেরণা দিন।"
+        url="https://promptshiksha.com/community/submit"
+        keywords="প্রম্পট জমা, বাংলা প্রম্পট শেয়ার"
+      />
+
+      <div className="container mx-auto px-4 py-12">
+        <div className="mx-auto max-w-3xl">
+          <div className="cartoon-card bg-white p-8 shadow-lg">
+            <div className="flex flex-col gap-3 text-center">
+              <div className="inline-flex items-center justify-center gap-3 self-center rounded-full bg-purple-100 px-5 py-2 text-sm font-bengali text-purple-700">
+                <Sparkles className="h-4 w-4" />
+                <span>প্রম্পট শিক্ষা কমিউনিটি</span>
+              </div>
+              <h1 className="text-3xl font-display text-purple-700 md:text-4xl">
+                আপনার প্রম্পট শেয়ার করুন
+              </h1>
+              <p className="font-bengali text-slate-600">
+                অনুপ্রেরণাদায়ী প্রম্পটটি কমিউনিটির সাথে ভাগ করুন। যতটা সম্ভব প্রেক্ষাপট ও ব্যবহার পদ্ধতি যোগ করুন যাতে সবাই উপকৃত হয়।
+              </p>
+            </div>
+
+            <div className="mt-6 grid gap-3 rounded-2xl border border-dashed border-purple-200 bg-purple-50 p-4 text-left">
+              <div className="flex items-start gap-3">
+                <Lightbulb className="mt-1 h-5 w-5 text-amber-500" />
+                <div>
+                  <h2 className="font-display text-lg text-purple-700">শেয়ারের আগে কয়েকটি টিপস</h2>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 font-bengali text-sm text-slate-600">
+                    <li>প্রম্পটটির উদ্দেশ্য এবং ব্যবহার ক্ষেত্র পরিষ্কারভাবে লিখুন।</li>
+                    <li>যদি নির্দিষ্ট টুল বা মডেলের জন্য হয়, তা উল্লেখ করুন।</li>
+                    <li>ট্যাগ ব্যবহার করে অন্যদের খুঁজে পেতে সহজ করুন।</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+
+            <form
+              className="mt-8 space-y-6"
+              onSubmit={(event) => {
+                event.preventDefault();
+                mutation.mutate();
+              }}
+            >
+              <div className="space-y-2">
+                <Label htmlFor="prompt-title" className="font-bengali text-base">
+                  প্রম্পটের শিরোনাম
+                </Label>
+                <Input
+                  id="prompt-title"
+                  value={formState.title}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, title: event.target.value }))
+                  }
+                  required
+                  maxLength={120}
+                  className="font-bengali"
+                  placeholder="উদাহরণ: বাংলা ব্লগ পোস্টের জন্য SEO আইডিয়া জেনারেটর"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="prompt-body" className="font-bengali text-base">
+                  প্রম্পটের মূল অংশ
+                </Label>
+                <Textarea
+                  id="prompt-body"
+                  value={formState.prompt}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, prompt: event.target.value }))
+                  }
+                  required
+                  rows={8}
+                  maxLength={MAX_PROMPT_LENGTH}
+                  className="font-bengali"
+                  placeholder="আপনার প্রম্পটটি বাংলায় লিখুন..."
+                />
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>ন্যূনতম ২০ অক্ষর</span>
+                  <span>{trimmedPrompt.length}/{MAX_PROMPT_LENGTH}</span>
+                </div>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="prompt-use-case" className="font-bengali text-base">
+                    ব্যবহার ক্ষেত্র (ঐচ্ছিক)
+                  </Label>
+                  <Input
+                    id="prompt-use-case"
+                    value={formState.use_case}
+                    onChange={(event) =>
+                      setFormState((current) => ({ ...current, use_case: event.target.value }))
+                    }
+                    className="font-bengali"
+                    placeholder="যেমন: SEO কন্টেন্ট, শিক্ষামূলক ভিডিও"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="prompt-language" className="font-bengali text-base">
+                    ভাষা
+                  </Label>
+                  <Input
+                    id="prompt-language"
+                    value={formState.language}
+                    onChange={(event) =>
+                      setFormState((current) => ({ ...current, language: event.target.value || "Bangla" }))
+                    }
+                    className="font-bengali"
+                    placeholder="Bangla"
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="prompt-description" className="font-bengali text-base">
+                  অতিরিক্ত নির্দেশনা (ঐচ্ছিক)
+                </Label>
+                <Textarea
+                  id="prompt-description"
+                  value={formState.description}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, description: event.target.value }))
+                  }
+                  rows={4}
+                  maxLength={600}
+                  className="font-bengali"
+                  placeholder="এই প্রম্পটটি ব্যবহার করার সময় বিশেষ কোনো নির্দেশনা থাকলে লিখুন"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="prompt-tags" className="font-bengali text-base">
+                  ট্যাগ (কমা দিয়ে আলাদা করুন)
+                </Label>
+                <Input
+                  id="prompt-tags"
+                  value={formState.tags}
+                  onChange={(event) =>
+                    setFormState((current) => ({ ...current, tags: event.target.value }))
+                  }
+                  className="font-bengali"
+                  placeholder="যেমন: শিক্ষা, ব্লগ, SEO"
+                />
+                {tagList.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {tagList.map((tag) => (
+                      <Badge key={tag} variant="secondary" className="font-bengali">
+                        #{tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="submitter-name" className="font-bengali text-base">
+                    আপনার নাম (ঐচ্ছিক)
+                  </Label>
+                  <Input
+                    id="submitter-name"
+                    value={formState.submitter_name}
+                    onChange={(event) => {
+                      const value = event.target.value;
+                      setFormState((current) => ({ ...current, submitter_name: value }));
+                      persistCommunityDisplayName(value);
+                    }}
+                    className="font-bengali"
+                    placeholder="আপনার নাম"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="submitter-email" className="font-bengali text-base">
+                    ইমেইল (ঐচ্ছিক)
+                  </Label>
+                  <Input
+                    id="submitter-email"
+                    type="email"
+                    value={formState.submitter_email}
+                    onChange={(event) =>
+                      setFormState((current) => ({ ...current, submitter_email: event.target.value }))
+                    }
+                    className="font-bengali"
+                    placeholder="name@example.com"
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="text-sm font-bengali text-muted-foreground">
+                  জমা দেয়ার মাধ্যমে আপনি আমাদের কমিউনিটি গাইডলাইন মেনে চলতে সম্মত হচ্ছেন।
+                </div>
+                <div className="flex items-center gap-3">
+                  <Button asChild variant="ghost" className="font-bengali">
+                    <Link to="/community/prompts">লাইব্রেরি দেখুন</Link>
+                  </Button>
+                  <Button
+                    type="submit"
+                    disabled={mutation.isPending || !isReady}
+                    className="flex items-center gap-2"
+                  >
+                    {mutation.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <PenSquare className="h-4 w-4" />
+                    )}
+                    <span className="font-bengali">প্রম্পট জমা দিন</span>
+                  </Button>
+                </div>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubmitPrompt;

--- a/src/types/community.ts
+++ b/src/types/community.ts
@@ -1,0 +1,23 @@
+export interface CommunityPrompt {
+  id: string;
+  title: string;
+  prompt: string;
+  description: string | null;
+  use_case: string | null;
+  language: string | null;
+  tags: string[];
+  submitter_name: string | null;
+  created_at: string;
+  upvote_count: number;
+  comment_count: number;
+  user_has_upvoted: boolean;
+}
+
+export interface PromptComment {
+  id: string;
+  prompt_id: string;
+  community_identity: string;
+  author_name: string | null;
+  content: string;
+  created_at: string;
+}

--- a/supabase/migrations/20250717090000-9c4f57a0-0c24-4a23-b19c-0d03bb5d5b77.sql
+++ b/supabase/migrations/20250717090000-9c4f57a0-0c24-4a23-b19c-0d03bb5d5b77.sql
@@ -1,0 +1,120 @@
+-- Create prompts table for community submissions
+CREATE TABLE public.prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  description TEXT,
+  use_case TEXT,
+  language TEXT DEFAULT 'Bangla',
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  submitter_name TEXT,
+  submitter_email TEXT,
+  created_by UUID REFERENCES auth.users(id),
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+-- Track metadata for community upvotes
+CREATE TABLE public.prompt_upvotes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt_id UUID NOT NULL REFERENCES public.prompts(id) ON DELETE CASCADE,
+  community_identity UUID NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX prompt_upvotes_unique_identity
+  ON public.prompt_upvotes (prompt_id, community_identity);
+
+-- Store user generated comments for prompts
+CREATE TABLE public.prompt_comments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt_id UUID NOT NULL REFERENCES public.prompts(id) ON DELETE CASCADE,
+  community_identity UUID NOT NULL,
+  author_name TEXT,
+  content TEXT NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_prompt_comments_prompt_id_created_at
+  ON public.prompt_comments (prompt_id, created_at DESC);
+
+-- Helper function to maintain updated_at timestamps
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prompts_set_updated_at
+BEFORE UPDATE ON public.prompts
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+-- Enable RLS and define policies for prompts table
+ALTER TABLE public.prompts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Prompts are viewable by everyone"
+  ON public.prompts
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY "Community members can submit prompts"
+  ON public.prompts
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+CREATE POLICY "Service role can manage prompts"
+  ON public.prompts
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Enable RLS for prompt upvotes
+ALTER TABLE public.prompt_upvotes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Upvotes are visible to everyone"
+  ON public.prompt_upvotes
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY "Community members can upvote prompts"
+  ON public.prompt_upvotes
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (true);
+
+CREATE POLICY "Users can retract their upvotes"
+  ON public.prompt_upvotes
+  FOR DELETE
+  TO anon, authenticated
+  USING (community_identity::text = current_setting('request.headers.x-community-identity', true));
+
+CREATE POLICY "Service role can manage upvotes"
+  ON public.prompt_upvotes
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Enable RLS for prompt comments
+ALTER TABLE public.prompt_comments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Comments are visible to everyone"
+  ON public.prompt_comments
+  FOR SELECT
+  USING (true);
+
+CREATE POLICY "Community members can comment"
+  ON public.prompt_comments
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (char_length(trim(content)) > 0);
+
+CREATE POLICY "Service role can manage comments"
+  ON public.prompt_comments
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+


### PR DESCRIPTION
## Summary
- add Supabase tables for community prompts, upvotes, and comments with RLS policies
- extend Supabase typings and add identity/profile utilities for community interactions
- implement community prompt listing and submission pages with reusable prompt card component and navigation updates

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68c9682c5bec8326be719d0072c4b6a5