### PR TITLE
Add browser process polyfill for logger

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,3 +1,4 @@
+import "@/polyfills/process";
 import winston from "winston";
 
 const { combine, colorize, errors, printf, splat, timestamp, uncolorize } = winston.format;

--- a/src/polyfills/process.ts
+++ b/src/polyfills/process.ts
@@ -1,0 +1,77 @@
+type ProcessEnv = Record<string, string | undefined>;
+
+type BrowserWritable = {
+  write: (...args: unknown[]) => void;
+};
+
+type ProcessLike = {
+  env?: ProcessEnv;
+  browser?: boolean;
+  cwd?: () => string;
+  on?: (...args: unknown[]) => void;
+  removeListener?: (...args: unknown[]) => void;
+  emit?: (...args: unknown[]) => boolean;
+  listeners?: (...args: unknown[]) => unknown[];
+  exit?: (code?: number) => void;
+  nextTick?: (callback: (...args: unknown[]) => void, ...args: unknown[]) => void;
+  pid?: number;
+  version?: string;
+  versions?: Record<string, string>;
+  execPath?: string;
+  getuid?: () => number;
+  getgid?: () => number;
+  stdout?: BrowserWritable;
+  stderr?: BrowserWritable;
+};
+
+type BrowserProcess = Required<
+  Omit<ProcessLike, "stdout" | "stderr" | "getuid" | "getgid">
+> & {
+  stdout?: BrowserWritable;
+  stderr?: BrowserWritable;
+  getuid?: () => number;
+  getgid?: () => number;
+};
+
+const isBrowser = typeof window !== "undefined";
+
+if (isBrowser) {
+  const globalTarget = globalThis as typeof globalThis & { process?: ProcessLike };
+
+  const existingProcess = globalTarget.process ?? {};
+
+  const ensureNextTick =
+    existingProcess.nextTick ??
+    ((callback: (...args: unknown[]) => void, ...args: unknown[]) => {
+      queueMicrotask(() => {
+        callback(...args);
+      });
+    });
+
+  const polyfilledProcess: BrowserProcess = {
+    env: {
+      ...(existingProcess.env ?? {}),
+      NODE_ENV: existingProcess.env?.NODE_ENV ?? import.meta.env.MODE,
+    },
+    browser: true,
+    cwd: existingProcess.cwd ?? (() => "/"),
+    on: existingProcess.on ?? (() => undefined),
+    removeListener: existingProcess.removeListener ?? (() => undefined),
+    emit: existingProcess.emit ?? (() => false),
+    listeners: existingProcess.listeners ?? (() => []),
+    exit: existingProcess.exit ?? (() => undefined),
+    nextTick: ensureNextTick,
+    pid: existingProcess.pid ?? 0,
+    version: existingProcess.version ?? "",
+    versions: existingProcess.versions ?? {},
+    execPath: existingProcess.execPath ?? "",
+    getuid: existingProcess.getuid,
+    getgid: existingProcess.getgid,
+    stdout: existingProcess.stdout,
+    stderr: existingProcess.stderr,
+  };
+
+  globalTarget.process = polyfilledProcess;
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a browser-safe `process` polyfill that provides the minimal APIs used by the winston logger
- ensure the logger module loads the polyfill before requiring winston so the runtime no longer crashes

## Testing
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c97578c9c48326af7f25279127f169