### PR TITLE
Add marketplace schema, listing page, and seller dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ const PrivacyPolicy = React.lazy(() => import("./pages/PrivacyPolicy"));
 const CookiePolicy = React.lazy(() => import("./pages/CookiePolicy"));
 const CommunityPrompts = React.lazy(() => import("./pages/Community/Prompts"));
 const SubmitPrompt = React.lazy(() => import("./pages/Community/SubmitPrompt"));
+const Marketplace = React.lazy(() => import("./pages/Marketplace"));
+const SellerDashboard = React.lazy(() => import("./pages/SellerDashboard"));
 
 // Initialize Google AdSense
 const adsLogger = createScopedLogger("adsense");
@@ -61,6 +63,8 @@ const App = () => {
                 <Route path="/cookie-policy" element={<CookiePolicy />} />
                 <Route path="/community/prompts" element={<CommunityPrompts />} />
                 <Route path="/community/submit" element={<SubmitPrompt />} />
+                <Route path="/marketplace" element={<Marketplace />} />
+                <Route path="/seller" element={<SellerDashboard />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/integrations/marketplace.ts
+++ b/src/integrations/marketplace.ts
@@ -1,0 +1,141 @@
+import { supabase } from "@/integrations/supabase/client"
+import type { Tables } from "@/integrations/supabase/types"
+import { createScopedLogger } from "@/lib/logger"
+import type {
+  MarketplacePrompt,
+  MarketplacePurchaseRequest,
+  MarketplacePurchaseResult,
+  SellerCommissionSummary,
+} from "@/types/marketplace"
+
+const logger = createScopedLogger("marketplace-integration")
+
+const mapPrompt = (row: Tables<"marketplace_prompts">): MarketplacePrompt => ({
+  id: row.id,
+  title: row.title,
+  description: row.description,
+  prompt: row.prompt,
+  tags: row.tags ?? [],
+  priceCents: row.price_cents,
+  currency: row.currency,
+  authorName: row.author_name,
+  authorAvatarUrl: row.author_avatar_url ?? undefined,
+  commissionRate: Number(row.commission_rate ?? "0"),
+  preview: row.preview ?? undefined,
+  metadata: (typeof row.metadata === "object" && row.metadata !== null
+    ? (row.metadata as Record<string, unknown>)
+    : {}),
+  isActive: Boolean(row.is_active),
+  createdAt: row.created_at,
+  updatedAt: row.updated_at,
+})
+
+export const fetchMarketplacePrompts = async (): Promise<MarketplacePrompt[]> => {
+  const { data, error } = await supabase
+    .from("marketplace_prompts")
+    .select("*")
+    .eq("is_active", true)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    logger.error("Failed to fetch marketplace prompts", { error })
+    throw error
+  }
+
+  return (data ?? []).map(mapPrompt)
+}
+
+export const fetchSellerPrompts = async (
+  authorId: string,
+): Promise<MarketplacePrompt[]> => {
+  const { data, error } = await supabase
+    .from("marketplace_prompts")
+    .select("*")
+    .eq("author_id", authorId)
+    .order("created_at", { ascending: false })
+
+  if (error) {
+    logger.error("Failed to fetch seller prompts", { error, authorId })
+    throw error
+  }
+
+  return (data ?? []).map(mapPrompt)
+}
+
+export const fetchSellerCommissionSummary = async (
+  authorId: string,
+): Promise<SellerCommissionSummary[]> => {
+  const { data, error } = await supabase.rpc("get_seller_commission_summary", {
+    p_author_id: authorId,
+  })
+
+  if (error) {
+    logger.error("Failed to fetch seller commission summary", { error, authorId })
+    throw error
+  }
+
+  return (data ?? []).map((entry) => ({
+    promptId: entry.prompt_id,
+    promptTitle: entry.prompt_title,
+    totalSales: Number(entry.total_sales ?? 0),
+    totalRevenueCents: Number(entry.total_revenue_cents ?? 0),
+    totalCommissionCents: Number(entry.total_commission_cents ?? 0),
+    totalPayoutCents: Number(entry.total_payout_cents ?? 0),
+  }))
+}
+
+interface MarketplacePurchaseOptions extends MarketplacePurchaseRequest {
+  saleAmountCents?: number
+}
+
+export const purchaseMarketplacePrompt = async (
+  request: MarketplacePurchaseOptions,
+): Promise<MarketplacePurchaseResult> => {
+  const metadata = {
+    source: "marketplace-web",
+    requested_amount: request.saleAmountCents,
+  }
+
+  const { data, error } = await supabase.rpc("record_marketplace_sale", {
+    p_prompt_id: request.promptId,
+    p_buyer_email: request.buyerEmail,
+    p_payment_reference: request.paymentReference,
+    p_sale_amount_cents: request.saleAmountCents,
+    p_metadata: metadata,
+  })
+
+  if (error) {
+    logger.error("Failed to record marketplace sale", { error, request })
+    throw error
+  }
+
+  const saleRecord = data?.[0]
+
+  if (!saleRecord) {
+    const err = new Error("Sale was not recorded by Supabase")
+    logger.error("Missing sale record in RPC response", { request })
+    throw err
+  }
+
+  return {
+    saleId: saleRecord.sale_id,
+    promptId: saleRecord.prompt_id,
+    saleAmountCents: saleRecord.sale_amount_cents,
+    commissionCents: saleRecord.commission_cents,
+    sellerEarningsCents: saleRecord.seller_earnings_cents,
+    createdAt: saleRecord.created_at,
+  }
+}
+
+export const formatCurrency = (cents: number, currency = "BDT") => {
+  try {
+    return new Intl.NumberFormat("bn-BD", {
+      style: "currency",
+      currency,
+      minimumFractionDigits: 2,
+    }).format(cents / 100)
+  } catch (error) {
+    logger.warn("Falling back to manual currency formatting", { error, cents, currency })
+    return `${(cents / 100).toFixed(2)} ${currency}`
+  }
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,116 @@ export type Database = {
   }
   public: {
     Tables: {
+      marketplace_prompts: {
+        Row: {
+          author_avatar_url: string | null
+          author_id: string | null
+          author_name: string
+          commission_rate: string
+          created_at: string
+          currency: string
+          description: string | null
+          id: string
+          is_active: boolean
+          metadata: Json
+          preview: string | null
+          price_cents: number
+          prompt: string
+          tags: string[]
+          title: string
+          updated_at: string
+        }
+        Insert: {
+          author_avatar_url?: string | null
+          author_id?: string | null
+          author_name: string
+          commission_rate?: string
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          metadata?: Json
+          preview?: string | null
+          price_cents: number
+          prompt: string
+          tags?: string[]
+          title: string
+          updated_at?: string
+        }
+        Update: {
+          author_avatar_url?: string | null
+          author_id?: string | null
+          author_name?: string
+          commission_rate?: string
+          created_at?: string
+          currency?: string
+          description?: string | null
+          id?: string
+          is_active?: boolean
+          metadata?: Json
+          preview?: string | null
+          price_cents?: number
+          prompt?: string
+          tags?: string[]
+          title?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketplace_prompts_author_id_fkey"
+            columns: ["author_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+            referencedSchema: "auth"
+          }
+        ]
+      }
+      marketplace_sales: {
+        Row: {
+          buyer_email: string | null
+          commission_cents: number
+          created_at: string
+          id: string
+          metadata: Json
+          payment_reference: string | null
+          prompt_id: string
+          sale_amount_cents: number
+          seller_earnings_cents: number
+        }
+        Insert: {
+          buyer_email?: string | null
+          commission_cents: number
+          created_at?: string
+          id?: string
+          metadata?: Json
+          payment_reference?: string | null
+          prompt_id: string
+          sale_amount_cents: number
+          seller_earnings_cents: number
+        }
+        Update: {
+          buyer_email?: string | null
+          commission_cents?: number
+          created_at?: string
+          id?: string
+          metadata?: Json
+          payment_reference?: string | null
+          prompt_id?: string
+          sale_amount_cents?: number
+          seller_earnings_cents?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "marketplace_sales_prompt_id_fkey"
+            columns: ["prompt_id"]
+            isOneToOne: false
+            referencedRelation: "marketplace_prompts"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
       prompt_comments: {
         Row: {
           author_name: string | null
@@ -197,6 +307,36 @@ export type Database = {
       get_newsletter_stats: {
         Args: Record<PropertyKey, never>
         Returns: Json
+      }
+      get_seller_commission_summary: {
+        Args: {
+          p_author_id: string
+        }
+        Returns: {
+          prompt_id: string
+          prompt_title: string
+          total_sales: number
+          total_revenue_cents: number
+          total_commission_cents: number
+          total_payout_cents: number
+        }[]
+      }
+      record_marketplace_sale: {
+        Args: {
+          p_prompt_id: string
+          p_buyer_email?: string
+          p_payment_reference?: string
+          p_sale_amount_cents?: number
+          p_metadata?: Json
+        }
+        Returns: {
+          sale_id: string
+          prompt_id: string
+          sale_amount_cents: number
+          commission_cents: number
+          seller_earnings_cents: number
+          created_at: string
+        }[]
       }
     }
     Enums: {

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,0 +1,412 @@
+import { useMemo, useState } from "react"
+import { useMutation, useQuery } from "@tanstack/react-query"
+import {
+  AlertCircle,
+  Search,
+  ShieldCheck,
+  ShoppingCart,
+  Sparkles,
+  TrendingUp,
+} from "lucide-react"
+
+import SEOHead from "@/components/SEOHead"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Skeleton } from "@/components/ui/skeleton"
+import { useToast } from "@/hooks/use-toast"
+import {
+  fetchMarketplacePrompts,
+  formatCurrency,
+  purchaseMarketplacePrompt,
+} from "@/integrations/marketplace"
+import type { MarketplacePrompt } from "@/types/marketplace"
+
+const Marketplace = () => {
+  const { toast } = useToast()
+  const [searchTerm, setSearchTerm] = useState("")
+  const [selectedTag, setSelectedTag] = useState<string | null>(null)
+  const [activePrompt, setActivePrompt] = useState<MarketplacePrompt | null>(
+    null,
+  )
+  const [buyerEmail, setBuyerEmail] = useState("")
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
+  const {
+    data: prompts = [],
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ["marketplace", "prompts"],
+    queryFn: fetchMarketplacePrompts,
+    staleTime: 60_000,
+  })
+
+  const availableTags = useMemo(() => {
+    const tagSet = new Set<string>()
+    prompts.forEach((prompt) => {
+      prompt.tags.forEach((tag) => {
+        if (tag) {
+          tagSet.add(tag)
+        }
+      })
+    })
+
+    return Array.from(tagSet).sort((a, b) => a.localeCompare(b))
+  }, [prompts])
+
+  const filteredPrompts = useMemo(() => {
+    if (!prompts.length) {
+      return []
+    }
+
+    const normalized = searchTerm.trim().toLowerCase()
+
+    return prompts.filter((prompt) => {
+      const matchesTag = selectedTag ? prompt.tags.includes(selectedTag) : true
+
+      if (!normalized) {
+        return matchesTag
+      }
+
+      const haystacks = [
+        prompt.title,
+        prompt.description ?? "",
+        prompt.authorName,
+        prompt.tags.join(" "),
+      ].map((value) => value.toLowerCase())
+
+      const matchesSearch = haystacks.some((value) => value.includes(normalized))
+
+      return matchesTag && matchesSearch
+    })
+  }, [prompts, searchTerm, selectedTag])
+
+  const purchaseMutation = useMutation({
+    mutationFn: purchaseMarketplacePrompt,
+    onSuccess: (result) => {
+      toast({
+        title: "ক্রয় সফল", // Purchase Successful
+        description: `আপনার মোট মূল্য ${formatCurrency(result.saleAmountCents)}। প্রম্পটটি এখন আপনার ইমেইলে পাঠানো হবে।`,
+      })
+      setIsDialogOpen(false)
+      setActivePrompt(null)
+      setBuyerEmail("")
+    },
+    onError: (mutationError) => {
+      const description =
+        mutationError instanceof Error
+          ? mutationError.message
+          : "অজানা কারণে পেমেন্ট সম্পন্ন হয়নি।" // Unknown error
+      toast({
+        title: "ক্রয় ব্যর্থ", // Purchase failed
+        description,
+        variant: "destructive",
+      })
+    },
+  })
+
+  const openPurchaseDialog = (prompt: MarketplacePrompt) => {
+    setActivePrompt(prompt)
+    setIsDialogOpen(true)
+  }
+
+  const handleDialogChange = (open: boolean) => {
+    setIsDialogOpen(open)
+    if (!open) {
+      setActivePrompt(null)
+      setBuyerEmail("")
+    }
+  }
+
+  const handleConfirmPurchase = () => {
+    if (!activePrompt) {
+      return
+    }
+
+    purchaseMutation.mutate({
+      promptId: activePrompt.id,
+      buyerEmail: buyerEmail.trim() || undefined,
+    })
+  }
+
+  const renderLoadingState = () => (
+    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      {Array.from({ length: 6 }).map((_, index) => (
+        <Card key={`skeleton-${index}`} className="border border-orange-100/60">
+          <CardHeader>
+            <Skeleton className="h-6 w-3/4" />
+            <Skeleton className="h-4 w-full" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+            <Skeleton className="h-4 w-2/3" />
+          </CardContent>
+          <CardFooter className="flex justify-between items-center">
+            <Skeleton className="h-10 w-24" />
+            <Skeleton className="h-10 w-20" />
+          </CardFooter>
+        </Card>
+      ))}
+    </div>
+  )
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-rose-50 to-orange-100">
+      <SEOHead
+        title="বাজার - প্রিমিয়াম প্রম্পট মার্কেটপ্লেস"
+        description="বিশ্বস্ত বাংলা প্রম্পট নির্মাতাদের কাছ থেকে প্রিমিয়াম প্রম্পট কিনুন এবং আপনার নিজস্ব সংগ্রহ তৈরি করুন।"
+        url="https://promptshiksha.com/marketplace"
+        keywords="Bangla prompt marketplace, premium prompts, বাংলা প্রম্পট"
+      />
+
+      <section className="border-b border-orange-200/60 bg-white/80 backdrop-blur">
+        <div className="container mx-auto px-4 py-16 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-orange-500 to-rose-500 text-white shadow-lg">
+            <ShoppingCart className="h-6 w-6" />
+          </div>
+          <h1 className="mt-6 text-3xl font-extrabold tracking-tight text-slate-900 md:text-4xl">
+            বাংলা প্রম্পট মার্কেটপ্লেস
+          </h1>
+          <p className="mx-auto mt-4 max-w-2xl text-base text-slate-600 md:text-lg">
+            শীর্ষস্থানীয় প্রম্পট নির্মাতাদের দক্ষতা দিয়ে তৈরি প্রিমিয়াম প্রম্পট সংগ্রহ। যাচাই করা ফর্মুলা ও বাংলা কনটেক্সটে অপ্টিমাইজড স্ট্র্যাটেজি দিয়ে আপনার জেনারেটিভ এআই ফলাফল উন্নত করুন।
+          </p>
+          <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
+            <div className="flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700">
+              <ShieldCheck className="h-5 w-5" />
+              <span>নিরাপদ ডিজিটাল পেমেন্ট</span>
+            </div>
+            <div className="flex items-center gap-2 rounded-full bg-amber-100 px-4 py-2 text-amber-700">
+              <TrendingUp className="h-5 w-5" />
+              <span>কমিশন ট্র্যাকিং স্বয়ংক্রিয়</span>
+            </div>
+            <div className="flex items-center gap-2 rounded-full bg-rose-100 px-4 py-2 text-rose-700">
+              <Sparkles className="h-5 w-5" />
+              <span>কমিউনিটি যাচাইকৃত নির্মাতা</span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <main className="container mx-auto px-4 py-16">
+        <div className="flex flex-col gap-6 rounded-3xl bg-white/80 p-8 shadow-xl shadow-orange-200/40">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-slate-900">
+                প্রিমিয়াম প্রম্পট সংগ্রহ
+              </h2>
+              <p className="mt-1 text-sm text-slate-600">
+                পারফরমেন্স প্রমাণিত প্রম্পট গুলো থেকে বেছে নিন। প্রতিটি ক্রয়ে নির্মাতার জন্য স্বয়ংক্রিয় কমিশন রেকর্ড হয়।
+              </p>
+            </div>
+            <div className="relative w-full md:w-80">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+              <Input
+                value={searchTerm}
+                onChange={(event) => setSearchTerm(event.target.value)}
+                placeholder="প্রম্পট খুঁজুন..."
+                className="pl-10"
+              />
+            </div>
+          </div>
+
+          {availableTags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-medium text-slate-600">শ্রেণি:</span>
+              {availableTags.map((tag) => {
+                const isActive = selectedTag === tag
+                return (
+                  <Badge
+                    key={tag}
+                    variant={isActive ? "default" : "secondary"}
+                    className={`cursor-pointer px-3 py-1 ${
+                      isActive
+                        ? "bg-orange-500 text-white hover:bg-orange-500"
+                        : "bg-orange-100/80 text-orange-700 hover:bg-orange-200"
+                    }`}
+                    onClick={() => setSelectedTag(isActive ? null : tag)}
+                  >
+                    #{tag}
+                  </Badge>
+                )
+              })}
+              {selectedTag && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setSelectedTag(null)}
+                >
+                  ফিল্টার রিসেট
+                </Button>
+              )}
+            </div>
+          )}
+
+          {isError && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>ডেটা লোড ব্যর্থ</AlertTitle>
+              <AlertDescription>
+                {error instanceof Error
+                  ? error.message
+                  : "সার্ভার থেকে তথ্য আনতে সমস্যা হচ্ছে। কিছুক্ষণ পরে আবার চেষ্টা করুন।"}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {isLoading && renderLoadingState()}
+
+          {!isLoading && filteredPrompts.length === 0 && (
+            <Card className="border border-dashed border-orange-200 bg-orange-50/70 text-center">
+              <CardHeader>
+                <CardTitle className="text-xl text-slate-800">
+                  কোন প্রম্পট পাওয়া যায়নি
+                </CardTitle>
+                <CardDescription>
+                  আপনার সার্চ বা ফিল্টারের সাথে মিলে এমন কোন প্রম্পট এই মুহূর্তে নেই। ফিল্টার পরিবর্তন করে আবার চেষ্টা করুন।
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
+
+          {!isLoading && filteredPrompts.length > 0 && (
+            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {filteredPrompts.map((prompt) => (
+                <Card
+                  key={prompt.id}
+                  className="group flex h-full flex-col border border-orange-100/80 bg-white/90 backdrop-blur transition hover:-translate-y-1 hover:shadow-lg hover:shadow-orange-200/60"
+                >
+                  <CardHeader>
+                    <CardTitle className="flex items-start justify-between gap-3 text-lg text-slate-900">
+                      <span>{prompt.title}</span>
+                      <Badge className="bg-gradient-to-r from-orange-500 to-rose-500 text-white">
+                        {formatCurrency(prompt.priceCents, prompt.currency)}
+                      </Badge>
+                    </CardTitle>
+                    <CardDescription className="line-clamp-3 text-sm text-slate-600">
+                      {prompt.description || "বিস্তারিত বিবরণ উপলভ্য।"}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent className="flex flex-1 flex-col gap-4">
+                    <div className="space-y-1 text-sm text-slate-500">
+                      <p className="font-medium text-slate-700">
+                        নির্মাতা: {prompt.authorName}
+                      </p>
+                      <p>কমিশন: {(prompt.commissionRate * 100).toFixed(0)}%</p>
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      {prompt.tags.map((tag) => (
+                        <Badge
+                          key={`${prompt.id}-${tag}`}
+                          variant="outline"
+                          className="border-orange-200 text-orange-700"
+                        >
+                          #{tag}
+                        </Badge>
+                      ))}
+                    </div>
+                  </CardContent>
+                  <CardFooter className="mt-auto flex items-center justify-between">
+                    <div className="text-xs text-slate-500">
+                      সর্বশেষ আপডেট {new Date(prompt.updatedAt).toLocaleDateString("bn-BD")}
+                    </div>
+                    <Button onClick={() => openPurchaseDialog(prompt)}>
+                      <ShoppingCart className="mr-2 h-4 w-4" /> ক্রয় করুন
+                    </Button>
+                  </CardFooter>
+                </Card>
+              ))}
+            </div>
+          )}
+        </div>
+      </main>
+
+      <Dialog open={isDialogOpen} onOpenChange={handleDialogChange}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>প্রম্পট ক্রয় নিশ্চিতকরণ</DialogTitle>
+            <DialogDescription>
+              প্রম্পটটি কেনার জন্য নিচের তথ্য যাচাই করে নিশ্চিত করুন। পেমেন্ট সফল হলে ইমেইলের মাধ্যমে প্রম্পটটি পাঠানো হবে।
+            </DialogDescription>
+          </DialogHeader>
+
+          {activePrompt && (
+            <div className="space-y-4">
+              <div className="rounded-xl bg-orange-50/80 p-4 text-sm text-slate-700">
+                <p className="font-semibold text-slate-900">{activePrompt.title}</p>
+                <p className="mt-1 text-slate-600">
+                  মূল্য: {formatCurrency(activePrompt.priceCents, activePrompt.currency)}
+                </p>
+                <p className="text-slate-500">
+                  নির্মাতা কমিশন স্বয়ংক্রিয়ভাবে {(
+                    activePrompt.commissionRate * 100
+                  ).toFixed(0)}% হিসেবে যোগ হবে।
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="buyer-email">ইমেইল (ঐচ্ছিক)</Label>
+                <Input
+                  id="buyer-email"
+                  type="email"
+                  autoComplete="email"
+                  placeholder="আপনার ইমেইল লিখুন"
+                  value={buyerEmail}
+                  onChange={(event) => setBuyerEmail(event.target.value)}
+                  disabled={purchaseMutation.isPending}
+                />
+                <p className="text-xs text-slate-500">
+                  আমরা প্রম্পট ফাইল এবং ভবিষ্যৎ আপডেট এই ইমেইলে পাঠাবো।
+                </p>
+              </div>
+            </div>
+          )}
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleDialogChange(false)}
+              disabled={purchaseMutation.isPending}
+            >
+              বাতিল
+            </Button>
+            <Button
+              type="button"
+              onClick={handleConfirmPurchase}
+              disabled={purchaseMutation.isPending || !activePrompt}
+            >
+              {purchaseMutation.isPending ? "প্রসেস হচ্ছে..." : "পেমেন্ট সম্পন্ন করুন"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+export default Marketplace

--- a/src/pages/SellerDashboard.tsx
+++ b/src/pages/SellerDashboard.tsx
@@ -1,0 +1,386 @@
+import { useEffect, useMemo, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
+import { BarChart3, DollarSign, RefreshCcw, Users } from "lucide-react"
+
+import SEOHead from "@/components/SEOHead"
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+import { useToast } from "@/hooks/use-toast"
+import {
+  fetchSellerCommissionSummary,
+  fetchSellerPrompts,
+  formatCurrency,
+} from "@/integrations/marketplace"
+import { supabase } from "@/integrations/supabase/client"
+import { createScopedLogger } from "@/lib/logger"
+import type {
+  MarketplacePrompt,
+  SellerCommissionSummary,
+} from "@/types/marketplace"
+
+const logger = createScopedLogger("seller-dashboard")
+
+const SellerDashboard = () => {
+  const { toast } = useToast()
+  const [sellerId, setSellerId] = useState<string | null>(null)
+  const [manualSellerId, setManualSellerId] = useState("")
+  const [authChecked, setAuthChecked] = useState(false)
+
+  useEffect(() => {
+    const resolveUser = async () => {
+      const { data, error } = await supabase.auth.getUser()
+      if (error) {
+        logger.error("Failed to load current user", { error })
+      }
+
+      if (data?.user?.id) {
+        setSellerId(data.user.id)
+        setManualSellerId(data.user.id)
+      }
+
+      setAuthChecked(true)
+    }
+
+    resolveUser()
+  }, [])
+
+  const sellerPromptsQuery = useQuery({
+    queryKey: ["marketplace", "seller-prompts", sellerId],
+    queryFn: () => fetchSellerPrompts(sellerId as string),
+    enabled: Boolean(sellerId),
+    staleTime: 60_000,
+  })
+
+  const commissionSummaryQuery = useQuery({
+    queryKey: ["marketplace", "commission-summary", sellerId],
+    queryFn: () => fetchSellerCommissionSummary(sellerId as string),
+    enabled: Boolean(sellerId),
+    staleTime: 30_000,
+  })
+
+  const combinedPrompts = useMemo(() => {
+    if (!sellerPromptsQuery.data) {
+      return [] as Array<{
+        prompt: MarketplacePrompt
+        summary: SellerCommissionSummary
+      }>
+    }
+
+    const summaryMap = new Map(
+      (commissionSummaryQuery.data ?? []).map((entry) => [entry.promptId, entry]),
+    )
+
+    return sellerPromptsQuery.data.map((prompt) => ({
+      prompt,
+      summary:
+        summaryMap.get(prompt.id) ?? {
+          promptId: prompt.id,
+          promptTitle: prompt.title,
+          totalSales: 0,
+          totalRevenueCents: 0,
+          totalCommissionCents: 0,
+          totalPayoutCents: 0,
+        },
+    }))
+  }, [sellerPromptsQuery.data, commissionSummaryQuery.data])
+
+  const totals = useMemo(() => {
+    return combinedPrompts.reduce(
+      (acc, entry) => ({
+        totalSales: acc.totalSales + entry.summary.totalSales,
+        totalRevenueCents: acc.totalRevenueCents + entry.summary.totalRevenueCents,
+        totalCommissionCents:
+          acc.totalCommissionCents + entry.summary.totalCommissionCents,
+        totalPayoutCents: acc.totalPayoutCents + entry.summary.totalPayoutCents,
+        activePrompts: acc.activePrompts + (entry.prompt.isActive ? 1 : 0),
+      }),
+      {
+        totalSales: 0,
+        totalRevenueCents: 0,
+        totalCommissionCents: 0,
+        totalPayoutCents: 0,
+        activePrompts: 0,
+      },
+    )
+  }, [combinedPrompts])
+
+  const isLoading =
+    sellerPromptsQuery.isLoading || commissionSummaryQuery.isLoading
+  const hasError = sellerPromptsQuery.isError || commissionSummaryQuery.isError
+
+  const activeError = sellerPromptsQuery.error ?? commissionSummaryQuery.error
+
+  const handleManualLoad = () => {
+    const trimmed = manualSellerId.trim()
+    if (!trimmed) {
+      toast({
+        title: "সেলার আইডি প্রয়োজন",
+        description: "ড্যাশবোর্ড দেখতে আপনার সেলার আইডি দিন।",
+        variant: "destructive",
+      })
+      return
+    }
+
+    setSellerId(trimmed)
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 via-white to-amber-50">
+      <SEOHead
+        title="সেলার ড্যাশবোর্ড - প্রম্পট মার্কেটপ্লেস"
+        description="আপনার প্রিমিয়াম প্রম্পট বিক্রয়, আয় এবং কমিশন ট্র্যাক করুন।"
+        url="https://promptshiksha.com/seller"
+        keywords="Seller dashboard, prompt marketplace earnings"
+      />
+
+      <section className="border-b border-slate-200/60 bg-white/80 backdrop-blur">
+        <div className="container mx-auto px-4 py-16">
+          <div className="flex flex-col items-center text-center">
+            <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-lg">
+              <BarChart3 className="h-6 w-6" />
+            </div>
+            <h1 className="mt-6 text-3xl font-bold text-slate-900 md:text-4xl">
+              সেলার পারফরমেন্স ড্যাশবোর্ড
+            </h1>
+            <p className="mt-3 max-w-2xl text-base text-slate-600 md:text-lg">
+              মার্কেটপ্লেসে আপনার প্রকাশিত প্রম্পটগুলোর বিক্রয়, আয় এবং কমিশন রিয়েল-টাইমে ট্র্যাক করুন। Supabase ফাংশনের মাধ্যমে কমিশন স্বয়ংক্রিয়ভাবে আপডেট হয়।
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <main className="container mx-auto px-4 py-16">
+        <div className="grid gap-6 lg:grid-cols-3">
+          <Card className="lg:col-span-2">
+            <CardHeader className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle>সেলার আইডি যাচাই</CardTitle>
+                <CardDescription>
+                  Supabase অথেন্টিকেশন থেকে আমরা আপনার ইউজার আইডি সংগ্রহের চেষ্টা করি। প্রয়োজন হলে ম্যানুয়ালি আইডি দিন।
+                </CardDescription>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Input
+                  value={manualSellerId}
+                  onChange={(event) => setManualSellerId(event.target.value)}
+                  placeholder="আপনার সেলার আইডি"
+                  className="sm:w-64"
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={handleManualLoad}
+                >
+                  লোড করুন
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border border-emerald-100 bg-emerald-50/80 p-4 text-sm text-emerald-700">
+                  <p className="font-medium">বর্তমান সেলার আইডি</p>
+                  <p className="truncate text-base font-semibold text-emerald-900">
+                    {sellerId ?? "অজানা"}
+                  </p>
+                </div>
+                <div className="rounded-xl border border-amber-100 bg-amber-50/80 p-4 text-sm text-amber-700">
+                  <p className="font-medium">অথেন্টিকেশন অবস্থা</p>
+                  <p className="font-semibold text-amber-900">
+                    {authChecked
+                      ? sellerId
+                        ? "Supabase থেকে আইডি শনাক্ত করা হয়েছে"
+                        : "ম্যানুয়াল আইডি প্রয়োজন"
+                      : "পরীক্ষা চলছে..."}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+            <CardFooter className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+              <RefreshCcw className="h-4 w-4" />
+              <span>সেলার আইডি পরিবর্তন করলে ডেটা স্বয়ংক্রিয়ভাবে রিফ্রেশ হবে।</span>
+            </CardFooter>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>সেলারের দ্রুত পর্যালোচনা</CardTitle>
+              <CardDescription>
+                মোট বিক্রয় এবং আয়ের সারাংশ Supabase ফাংশন থেকে সংগ্রহ করা হয়েছে।
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <div className="flex items-center justify-between rounded-lg bg-slate-100/70 px-4 py-2">
+                <span className="flex items-center gap-2 font-medium text-slate-700">
+                  <Users className="h-4 w-4" /> মোট বিক্রয়
+                </span>
+                <span className="font-semibold text-slate-900">{totals.totalSales}</span>
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-slate-100/70 px-4 py-2">
+                <span className="flex items-center gap-2 font-medium text-slate-700">
+                  <DollarSign className="h-4 w-4" /> মোট আয়
+                </span>
+                <span className="font-semibold text-emerald-600">
+                  {formatCurrency(totals.totalRevenueCents)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-slate-100/70 px-4 py-2">
+                <span className="flex items-center gap-2 font-medium text-slate-700">
+                  কমিশন
+                </span>
+                <span className="font-semibold text-rose-600">
+                  {formatCurrency(totals.totalCommissionCents)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-slate-100/70 px-4 py-2">
+                <span className="flex items-center gap-2 font-medium text-slate-700">
+                  আপনার আয়
+                </span>
+                <span className="font-semibold text-slate-900">
+                  {formatCurrency(totals.totalPayoutCents)}
+                </span>
+              </div>
+              <div className="flex items-center justify-between rounded-lg bg-slate-100/70 px-4 py-2">
+                <span className="flex items-center gap-2 font-medium text-slate-700">
+                  সক্রিয় প্রম্পট
+                </span>
+                <span className="font-semibold text-slate-900">{totals.activePrompts}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        <div className="mt-10 rounded-3xl bg-white/90 p-6 shadow-xl shadow-amber-100/40">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <h2 className="text-2xl font-semibold text-slate-900">
+                প্রম্পট পারফরমেন্স
+              </h2>
+              <p className="text-sm text-slate-600">
+                প্রতিটি ক্রয়ে Supabase ফাংশনের মাধ্যমে কমিশন ও পেআউট ট্র্যাক করা হয়।
+              </p>
+            </div>
+            <div className="text-sm text-slate-500">
+              সর্বশেষ আপডেট {new Date().toLocaleString("bn-BD")}
+            </div>
+          </div>
+
+          {!sellerId && (
+            <Alert className="mt-6" variant="destructive">
+              <AlertTitle>সেলার আইডি প্রয়োজন</AlertTitle>
+              <AlertDescription>
+                ড্যাশবোর্ড লোড করতে আপনার Supabase ইউজার আইডি প্রদান করুন অথবা লগইন করুন।
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {hasError && (
+            <Alert className="mt-6" variant="destructive">
+              <AlertTitle>ডেটা লোড ব্যর্থ</AlertTitle>
+              <AlertDescription>
+                {activeError instanceof Error
+                  ? activeError.message
+                  : "Supabase থেকে তথ্য আনতে সমস্যা হয়েছে।"}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {isLoading && (
+            <div className="mt-6 space-y-3">
+              {Array.from({ length: 3 }).map((_, index) => (
+                <Skeleton key={`seller-row-${index}`} className="h-12 w-full" />
+              ))}
+            </div>
+          )}
+
+          {!isLoading && sellerId && combinedPrompts.length === 0 && !hasError && (
+            <Card className="mt-6 border border-dashed border-amber-200 bg-amber-50/70 text-center">
+              <CardHeader>
+                <CardTitle>এখনও কোন প্রম্পট প্রকাশ করেননি</CardTitle>
+                <CardDescription>
+                  আপনার প্রম্পট প্রকাশ করলে বিক্রয় ও কমিশন এখানে দেখা যাবে।
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
+
+          {!isLoading && combinedPrompts.length > 0 && (
+            <div className="mt-6 overflow-x-auto">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>শিরোনাম</TableHead>
+                    <TableHead>মূল্য</TableHead>
+                    <TableHead>মোট বিক্রয়</TableHead>
+                    <TableHead>মোট আয়</TableHead>
+                    <TableHead>কমিশন</TableHead>
+                    <TableHead>আপনার অংশ</TableHead>
+                    <TableHead>অবস্থা</TableHead>
+                    <TableHead>আপডেট</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {combinedPrompts.map(({ prompt, summary }) => (
+                    <TableRow key={prompt.id} className="hover:bg-amber-50/40">
+                      <TableCell className="max-w-xs font-medium text-slate-800">
+                        <div className="line-clamp-2">{prompt.title}</div>
+                      </TableCell>
+                      <TableCell>{formatCurrency(prompt.priceCents, prompt.currency)}</TableCell>
+                      <TableCell>{summary.totalSales}</TableCell>
+                      <TableCell>{formatCurrency(summary.totalRevenueCents)}</TableCell>
+                      <TableCell className="text-rose-600">
+                        {formatCurrency(summary.totalCommissionCents)}
+                      </TableCell>
+                      <TableCell className="text-emerald-600">
+                        {formatCurrency(summary.totalPayoutCents)}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={prompt.isActive ? "default" : "secondary"}
+                          className={
+                            prompt.isActive
+                              ? "bg-emerald-500 text-white hover:bg-emerald-500"
+                              : "bg-slate-200 text-slate-700"
+                          }
+                        >
+                          {prompt.isActive ? "সক্রিয়" : "নিষ্ক্রিয়"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        {new Date(prompt.updatedAt).toLocaleDateString("bn-BD")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+export default SellerDashboard

--- a/src/types/marketplace.ts
+++ b/src/types/marketplace.ts
@@ -1,0 +1,41 @@
+export interface MarketplacePrompt {
+  id: string
+  title: string
+  description?: string | null
+  prompt: string
+  tags: string[]
+  priceCents: number
+  currency: string
+  authorName: string
+  authorAvatarUrl?: string | null
+  commissionRate: number
+  preview?: string | null
+  metadata: Record<string, unknown>
+  isActive: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface MarketplacePurchaseRequest {
+  promptId: string
+  buyerEmail?: string
+  paymentReference?: string
+}
+
+export interface MarketplacePurchaseResult {
+  saleId: string
+  promptId: string
+  saleAmountCents: number
+  commissionCents: number
+  sellerEarningsCents: number
+  createdAt: string
+}
+
+export interface SellerCommissionSummary {
+  promptId: string
+  promptTitle: string
+  totalSales: number
+  totalRevenueCents: number
+  totalCommissionCents: number
+  totalPayoutCents: number
+}

--- a/supabase/migrations/20250720093000-add-marketplace-prompts.sql
+++ b/supabase/migrations/20250720093000-add-marketplace-prompts.sql
@@ -1,0 +1,203 @@
+-- Marketplace prompts schema for monetized listings
+CREATE TABLE public.marketplace_prompts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  title TEXT NOT NULL,
+  prompt TEXT NOT NULL,
+  description TEXT,
+  tags TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  price_cents INTEGER NOT NULL CHECK (price_cents >= 0),
+  currency TEXT NOT NULL DEFAULT 'BDT',
+  author_id UUID REFERENCES auth.users(id),
+  author_name TEXT NOT NULL,
+  author_avatar_url TEXT,
+  commission_rate NUMERIC(6,5) NOT NULL DEFAULT 0.20000 CHECK (commission_rate >= 0 AND commission_rate <= 1),
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  preview TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_marketplace_prompts_active_price
+  ON public.marketplace_prompts (is_active, price_cents DESC);
+
+CREATE INDEX idx_marketplace_prompts_tags
+  ON public.marketplace_prompts USING GIN (tags);
+
+CREATE TRIGGER marketplace_prompts_set_updated_at
+BEFORE UPDATE ON public.marketplace_prompts
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.marketplace_prompts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Marketplace prompts visible to everyone"
+  ON public.marketplace_prompts
+  FOR SELECT
+  USING (is_active);
+
+CREATE POLICY "Sellers manage their marketplace prompts"
+  ON public.marketplace_prompts
+  FOR ALL
+  TO authenticated
+  USING (auth.uid() = author_id OR auth.role() = 'service_role')
+  WITH CHECK (auth.uid() = author_id OR auth.role() = 'service_role');
+
+CREATE POLICY "Service role manages marketplace prompts"
+  ON public.marketplace_prompts
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Track purchases and platform commissions
+CREATE TABLE public.marketplace_sales (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  prompt_id UUID NOT NULL REFERENCES public.marketplace_prompts(id) ON DELETE CASCADE,
+  buyer_email TEXT,
+  sale_amount_cents INTEGER NOT NULL CHECK (sale_amount_cents >= 0),
+  commission_cents INTEGER NOT NULL CHECK (commission_cents >= 0),
+  seller_earnings_cents INTEGER NOT NULL CHECK (seller_earnings_cents >= 0),
+  payment_reference TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_marketplace_sales_prompt_id_created_at
+  ON public.marketplace_sales (prompt_id, created_at DESC);
+
+ALTER TABLE public.marketplace_sales ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Marketplace sales visible to sellers"
+  ON public.marketplace_sales
+  FOR SELECT
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.marketplace_prompts mp
+      WHERE mp.id = prompt_id
+        AND mp.author_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Service role manages marketplace sales"
+  ON public.marketplace_sales
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Function to record sales and commissions centrally
+CREATE OR REPLACE FUNCTION public.record_marketplace_sale(
+  p_prompt_id UUID,
+  p_buyer_email TEXT DEFAULT NULL,
+  p_payment_reference TEXT DEFAULT NULL,
+  p_sale_amount_cents INTEGER DEFAULT NULL,
+  p_metadata JSONB DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  sale_id UUID,
+  prompt_id UUID,
+  sale_amount_cents INTEGER,
+  commission_cents INTEGER,
+  seller_earnings_cents INTEGER,
+  created_at TIMESTAMP WITH TIME ZONE
+) AS $$
+DECLARE
+  prompt_record public.marketplace_prompts;
+  sale_amount INTEGER;
+  commission INTEGER;
+  seller_earnings INTEGER;
+  computed_metadata JSONB;
+BEGIN
+  SELECT *
+    INTO prompt_record
+  FROM public.marketplace_prompts
+  WHERE id = p_prompt_id
+    AND is_active
+  FOR UPDATE;
+
+  IF prompt_record.id IS NULL THEN
+    RAISE EXCEPTION 'Prompt not available for sale';
+  END IF;
+
+  sale_amount := COALESCE(p_sale_amount_cents, prompt_record.price_cents);
+
+  IF sale_amount < 0 THEN
+    RAISE EXCEPTION 'Sale amount must be positive';
+  END IF;
+
+  commission := floor(sale_amount * COALESCE(prompt_record.commission_rate, 0))::INTEGER;
+  IF commission < 0 THEN
+    commission := 0;
+  END IF;
+
+  seller_earnings := sale_amount - commission;
+  IF seller_earnings < 0 THEN
+    seller_earnings := 0;
+  END IF;
+
+  computed_metadata := COALESCE(p_metadata, '{}'::jsonb) || jsonb_build_object(
+    'currency', prompt_record.currency,
+    'commission_rate', prompt_record.commission_rate
+  );
+
+  RETURN QUERY
+  INSERT INTO public.marketplace_sales (
+    prompt_id,
+    buyer_email,
+    sale_amount_cents,
+    commission_cents,
+    seller_earnings_cents,
+    payment_reference,
+    metadata
+  )
+  VALUES (
+    prompt_record.id,
+    NULLIF(TRIM(p_buyer_email), ''),
+    sale_amount,
+    commission,
+    seller_earnings,
+    NULLIF(TRIM(p_payment_reference), ''),
+    computed_metadata
+  )
+  RETURNING id, prompt_id, sale_amount_cents, commission_cents, seller_earnings_cents, created_at;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public;
+
+COMMENT ON FUNCTION public.record_marketplace_sale IS 'Records a prompt sale and calculates platform commission / seller earnings.';
+
+-- Aggregated commission stats per seller
+CREATE OR REPLACE FUNCTION public.get_seller_commission_summary(p_author_id UUID)
+RETURNS TABLE (
+  prompt_id UUID,
+  prompt_title TEXT,
+  total_sales BIGINT,
+  total_revenue_cents BIGINT,
+  total_commission_cents BIGINT,
+  total_payout_cents BIGINT
+) AS $$
+BEGIN
+  RETURN QUERY
+  SELECT
+    mp.id,
+    mp.title,
+    COUNT(ms.id) AS total_sales,
+    COALESCE(SUM(ms.sale_amount_cents), 0)::BIGINT AS total_revenue_cents,
+    COALESCE(SUM(ms.commission_cents), 0)::BIGINT AS total_commission_cents,
+    COALESCE(SUM(ms.seller_earnings_cents), 0)::BIGINT AS total_payout_cents
+  FROM public.marketplace_prompts mp
+  LEFT JOIN public.marketplace_sales ms ON ms.prompt_id = mp.id
+  WHERE mp.author_id = p_author_id
+  GROUP BY mp.id, mp.title
+  ORDER BY mp.title;
+END;
+$$ LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public;
+
+COMMENT ON FUNCTION public.get_seller_commission_summary IS 'Provides aggregate commission and payout metrics for a seller.''s marketplace prompts.';
+GRANT EXECUTE ON FUNCTION public.record_marketplace_sale(UUID, TEXT, TEXT, INTEGER, JSONB) TO anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_seller_commission_summary(UUID) TO authenticated;


### PR DESCRIPTION
## Summary
- add Supabase marketplace tables, RLS policies, and commission tracking RPC helpers for prompt sales
- extend Supabase typings plus marketplace integration utilities for loading listings, purchases, and seller summaries
- build marketplace listing and seller dashboard pages and register new routes in the app shell

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68c9836143a083268c66fe57375f7a68