### PR TITLE
Fix Supabase env lookup for browser builds

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -6,8 +6,29 @@ import type { Database } from './types';
 // ✅ Unified client using env vars
 type EnvRecord = Record<string, string | undefined>;
 
-const globalContextEnv: EnvRecord =
-  (globalThis as { context?: { env?: EnvRecord } }).context?.env ?? {};
+const getGlobalContextEnv = (): EnvRecord => {
+  if (typeof globalThis === 'undefined') {
+    return {};
+  }
+
+  const globalObject = globalThis as Record<string, unknown>;
+  const maybeContext = Reflect.get(globalObject, 'context') as unknown;
+
+  if (typeof maybeContext === 'object' && maybeContext !== null) {
+    const maybeEnv = Reflect.get(
+      maybeContext as Record<string, unknown>,
+      'env',
+    ) as unknown;
+
+    if (typeof maybeEnv === 'object' && maybeEnv !== null) {
+      return maybeEnv as EnvRecord;
+    }
+  }
+
+  return {};
+};
+
+const globalContextEnv: EnvRecord = getGlobalContextEnv();
 
 let importMetaEnv: EnvRecord = {};
 try {


### PR DESCRIPTION
## Summary
- guard the Supabase client environment lookup so we safely read Cloudflare runtime variables
- use `Reflect.get` to avoid bundlers rewriting the access into a bare `context` reference and rely on the SUPABASE_* keys

## Testing
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68c9aef2f040832692143e98d13f34fc