### PR TITLE
Add language provider and restore locale-specific layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,26 +1,25 @@
 
 <!DOCTYPE html>
-<html lang="bn">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Creepster&display=swap" rel="stylesheet">
-    
+
     <!-- Primary Meta Tags -->
-    <title>প্রম্পট শিক্ষা - বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন | AI শিক্ষা</title>
-    <meta name="title" content="প্রম্পট শিক্ষা - বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন | AI শিক্ষা" />
-    <meta name="description" content="বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন। বিশেষজ্ঞ-ডিজাইন করা কোর্সগুলি আপনাকে AI মডেলগুলির সাথে কার্যকরভাবে যোগাযোগ করতে সাহায্য করবে। ChatGPT, Claude, Gemini এর সাথে কাজ করুন।" />
-    <meta name="keywords" content="প্রম্পট ইঞ্জিনিয়ারিং, বাংলা AI কোর্স, ChatGPT বাংলা, AI শিক্ষা, প্রম্পট রাইটিং, কৃত্রিম বুদ্ধিমত্তা, বাংলা টিউটোরিয়াল" />
-    <meta name="author" content="প্রম্পট শিক্ষা" />
-    <link rel="canonical" href="https://promptshiksha.com/" />
+    <title>BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace</title>
+    <meta name="title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <meta name="description" content="Launch bilingual prompt storefronts, sell culturally rich AI workflows, and reach verified global buyers with transparent revenue tools and enterprise compliance." />
+    <meta name="keywords" content="BanglaPrompt.ai, Bengali AI prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation" />
+    <meta name="author" content="BanglaPrompt.ai" />
+    <link rel="canonical" href="https://banglaprompt.ai/" />
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://promptshiksha.com/" />
-    <meta property="og:title" content="প্রম্পট শিক্ষা - বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন" />
-    <meta property="og:description" content="বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন। AI মডেলগুলির সাথে কার্যকরভাবে যোগাযোগ করতে শিখুন।" />
+    <meta property="og:url" content="https://banglaprompt.ai/" />
+    <meta property="og:title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <meta property="og:description" content="Sell and buy Bengali-first AI prompts with fair revenue splits, bilingual support, and audit-ready governance." />
     <meta property="og:image" content="/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
@@ -28,16 +27,16 @@
     
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
-    <meta property="twitter:url" content="https://promptshiksha.com/" />
-    <meta property="twitter:title" content="প্রম্পট শিক্ষা - বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন" />
-    <meta property="twitter:description" content="বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন। AI মডেলগুলির সাথে কার্যকরভাবে যোগাযোগ করতে শিখুন।" />
+    <meta property="twitter:url" content="https://banglaprompt.ai/" />
+    <meta property="twitter:title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <meta property="twitter:description" content="Sell and buy Bengali-first AI prompts with fair revenue splits, bilingual support, and audit-ready governance." />
     <meta property="twitter:image" content="/og-image.png" />
     
     <!-- Additional SEO Meta Tags -->
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1" />
     <meta name="googlebot" content="index, follow" />
     <meta name="bingbot" content="index, follow" />
-    <meta name="language" content="Bengali" />
+    <meta name="language" content="English, Bengali" />
     <meta name="geo.region" content="BD" />
     <meta name="geo.country" content="Bangladesh" />
     
@@ -62,40 +61,40 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "EducationalOrganization",
-      "name": "প্রম্পট শিক্ষা",
-      "description": "বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিক্ষা প্রতিষ্ঠান",
-      "url": "https://prompt-panda.pages.dev",
+      "@type": "Organization",
+      "name": "BanglaPrompt.ai",
+      "description": "Bangladesh’s first global AI prompt marketplace with bilingual storefronts and compliant prompt commerce",
+      "url": "https://banglaprompt.ai",
       "logo": "/og-image.png",
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer service",
-        "availableLanguage": "Bengali"
+        "availableLanguage": ["English", "Bengali"]
       },
       "address": {
         "@type": "PostalAddress",
         "addressCountry": "BD"
       },
       "sameAs": [
-        "https://medium.com/@md.abir1203"
+        "https://www.linkedin.com/company/banglaprompt-ai/"
       ]
     }
     </script>
-    
+
     <!-- Course Structured Data -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Course",
-      "name": "বাংলায় প্রম্পট ইঞ্জিনিয়ারিং কোর্স",
-      "description": "ChatGPT, Claude, Gemini এর সাথে কার্যকরভাবে কাজ করার জন্য প্রম্পট ইঞ্জিনিয়ারিং শিখুন",
+      "name": "Bengali-first prompt engineering playbooks",
+      "description": "Learn to deploy culturally aware prompts for GPT-4.1, Claude 3, and Gemini Ultra across global teams.",
       "provider": {
         "@type": "Organization",
-        "name": "প্রম্পট শিক্ষা"
+        "name": "BanglaPrompt.ai"
       },
-      "inLanguage": "bn",
+      "inLanguage": ["en", "bn"],
       "courseMode": "online",
-      "educationalLevel": "beginner"
+      "educationalLevel": "intermediate"
     }
     </script>
     

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,101 +1,155 @@
+import { useState } from "react";
+import { BarChart3, Building2, ShieldCheck } from "lucide-react";
 
-import React from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Award, Users, BookOpen, Star } from 'lucide-react';
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const enterpriseTracks = [
+  {
+    key: "ops",
+    icon: Building2,
+    titleEn: "Multilingual Prompt Ops",
+    titleBn: "মাল্টিলিঙ্গুয়াল প্রম্পট অপারেশন",
+    descriptionEn:
+      "Deploy curated prompt libraries across South Asia, the Middle East, and diaspora markets with governance guardrails and co-creation workflows.",
+    descriptionBn:
+      "দক্ষিণ এশিয়া, মধ্যপ্রাচ্য ও প্রবাসী বাজারে শাসনব্যবস্থা ও কো-ক্রিয়েশন ওয়ার্কফ্লোসহ কিউরেটেড প্রম্পট লাইব্রেরি চালু করুন।",
+    highlights: [
+      "Localized tone packs for English, Bangla, Arabic, Hindi",
+      "Role-based access with SOC 2-ready audit logs",
+      "Enterprise SLA with 24/7 bilingual concierge",
+    ],
+    highlightsBn: [
+      "ইংরেজি, বাংলা, আরবি, হিন্দির জন্য টোন প্যাক",
+      "রোল-ভিত্তিক অ্যাক্সেস ও SOC 2-রেডি অডিট লগ",
+      "২৪/৭ দ্বিভাষিক কনসিয়ার্জসহ এন্টারপ্রাইজ SLA",
+    ],
+  },
+  {
+    key: "compliance",
+    icon: ShieldCheck,
+    titleEn: "Compliance Toolkit",
+    titleBn: "কমপ্লায়েন্স টুলকিট",
+    descriptionEn:
+      "Mitigate risk with embedded legal reviews, consent capture, and GDPR/SR5K-ready documentation.",
+    descriptionBn:
+      "নির্মিত লিগ্যাল রিভিউ, সম্মতি সংগ্রহ ও GDPR/SR5K ডকুমেন্টেশন দিয়ে ঝুঁকি কমান।",
+    highlights: [
+      "Dynamic PII masking with cultural context",
+      "Responsible AI playbooks co-written with Dhaka legal partners",
+      "Localized procurement decks for Fortune 500 teams",
+    ],
+    highlightsBn: [
+      "সাংস্কৃতিক প্রেক্ষাপটসহ ডায়নামিক PII মাস্কিং",
+      "ঢাকার আইন বিশেষজ্ঞদের সঙ্গে তৈরি রেসপনসিবল AI প্লেবুক",
+      "ফর্চুন ৫০০ টিমের জন্য লোকালাইজড প্রোকিউরমেন্ট ডেক",
+    ],
+  },
+  {
+    key: "analytics",
+    icon: BarChart3,
+    titleEn: "Analytics & Governance",
+    titleBn: "অ্যানালিটিক্স ও গভর্নেন্স",
+    descriptionEn:
+      "Monitor impact through predictive dashboards, localization insights, and collaborative performance reviews.",
+    descriptionBn:
+      "প্রেডিক্টিভ ড্যাশবোর্ড, লোকালাইজেশন ইনসাইট ও যৌথ পারফরম্যান্স রিভিউ দিয়ে প্রভাব পরিমাপ করুন।",
+    highlights: [
+      "Cross-market benchmarking for 70+ countries",
+      "Creator-enterprise shared KPI cockpit",
+      "Currency-aware royalty and usage forecasting",
+    ],
+    highlightsBn: [
+      "৭০+ দেশের ক্রস-মার্কেট বেঞ্চমার্ক",
+      "ক্রিয়েটর ও এন্টারপ্রাইজের যৌথ KPI ককপিট",
+      "কারেন্সি সংবেদনশীল রয়্যালটি ও ব্যবহারের পূর্বাভাস",
+    ],
+  },
+];
+
+const complianceBadges = [
+  { labelEn: "GDPR Ready", labelBn: "GDPR প্রস্তুত" },
+  { labelEn: "ISO 27001", labelBn: "ISO 27001" },
+  { labelEn: "SOC 2", labelBn: "SOC 2" },
+  { labelEn: "Bangladesh Data Protection", labelBn: "বাংলাদেশ ডেটা প্রোটেকশন" },
+];
 
 const About = () => {
-  const stats = [
-    { icon: Users, number: '১০,০০০+', label: 'শিক্ষার্থী' },
-    { icon: BookOpen, number: '৫০+', label: 'কোর্স মডিউল' },
-    { icon: Award, number: '৯৮%', label: 'সন্তুষ্ট শিক্ষার্থী' },
-    { icon: Star, number: '৪.৯', label: 'গড় রেটিং' }
-  ];
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+  const [activeTrack, setActiveTrack] = useState(enterpriseTracks[0].key);
+  const track = enterpriseTracks.find((item) => item.key === activeTrack) ?? enterpriseTracks[0];
 
   return (
-    <section id="about" className="py-20 bangladesh-pattern">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 text-primary rounded-full mb-6 border border-primary/20">
-            <span className="text-xl">🌱</span>
-            <span className="font-bengali font-medium">আমাদের শেকড় ও স্বপ্ন</span>
-          </div>
-          <h2 className="text-4xl font-bold font-display text-gray-900 mb-4">
-            আমাদের সম্পর্কে
-          </h2>
-          <p className="text-xl text-gray-600 font-bengali max-w-3xl mx-auto leading-relaxed">
-            বাংলার মাটি থেকে জন্ম নেওয়া, বিশ্বমানের AI শিক্ষার স্বপ্ন নিয়ে
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-12 items-center mb-16">
-          <div>
-            <h3 className="text-3xl font-bold font-bengali text-gray-900 mb-6">
-              আমাদের মিশন
-            </h3>
-            <p className="text-lg font-bengali text-gray-700 mb-6 leading-relaxed">
-              আমরা বিশ্বাস করি যে প্রযুক্তির সাথে আমাদের মাতৃভাষার সমন্বয়ে 
-              তৈরি হবে নতুন সম্ভাবনার জগৎ। বাংলাদেশের তরুণ প্রজন্মকে AI যুগের 
-              নেতৃত্ব দেওয়ার জন্য প্রস্তুত করাই আমাদের লক্ষ্য।
+    <section id="enterprise" className="section bg-gradient-to-b from-primary/5 via-transparent to-background">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid gap-16 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-8">
+            <p className="section-eyebrow">{isEnglish ? "Enterprise Solutions" : "এন্টারপ্রাইজ সল্যুশন"}</p>
+            <h2 className="section-heading">
+              {isEnglish
+                ? "Cultural intelligence with enterprise rigour."
+                : "সাংস্কৃতিক বুদ্ধিমত্তা, এন্টারপ্রাইজ কঠোরতার সাথে।"}
+            </h2>
+            <p className="section-subheading">
+              {isEnglish
+                ? "Launch culturally fluent AI experiences across South Asia, the Middle East, and diaspora markets with audit-grade oversight."
+                : "দক্ষিণ এশিয়া, মধ্যপ্রাচ্য ও প্রবাসী বাজারে সাংস্কৃতিকভাবে প্রাসঙ্গিক এআই অভিজ্ঞতা চালু করুন, অডিটযোগ্য নজরদারির নিশ্চয়তাসহ।"}
             </p>
-            <p className="text-lg font-bengali text-gray-700 leading-relaxed">
-              আমাদের দেশীয় প্রজ্ঞা আর আধুনিক প্রযুক্তির মেলবন্ধনে গড়ে তুলছি 
-              এমন একটি শিক্ষাব্যবস্থা যা প্রতিটি বাঙালিকে বিশ্বমানের দক্ষতায় 
-              এগিয়ে নিয়ে যাবে।
-            </p>
-          </div>
-          <div className="grid grid-cols-2 gap-6">
-            {stats.map((stat, index) => (
-              <Card key={index} className="text-center hover:shadow-lg transition-shadow">
-                <CardHeader className="pb-2">
-                  <stat.icon className="w-8 h-8 text-blue-600 mx-auto" />
-                </CardHeader>
-                <CardContent>
-                  <CardTitle className="text-2xl font-bold text-gray-900 mb-1">
-                    {stat.number}
-                  </CardTitle>
-                  <CardDescription className="font-bengali">
-                    {stat.label}
-                  </CardDescription>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        </div>
 
-        <div className="cultural-card rounded-2xl p-8 text-center border-primary/20">
-          <div className="flex items-center justify-center gap-3 mb-6">
-            <span className="text-3xl">🇧🇩</span>
-            <h3 className="text-2xl font-bold font-display text-primary">
-              কেন প্রম্পট শিক্ষা বেছে নেবেন?
-            </h3>
-          </div>
-          <div className="grid md:grid-cols-3 gap-6 mt-8">
-            <div className="text-center">
-              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-primary/10 flex items-center justify-center">
-                <span className="text-2xl">🌏</span>
+            <div className="glass-panel rounded-[2rem] p-8">
+              <div className="grid gap-3 text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground sm:grid-cols-2 lg:grid-cols-4">
+                {complianceBadges.map((badge) => (
+                  <span key={badge.labelEn} className="rounded-full border border-white/60 bg-white/70 px-4 py-2 text-center shadow-sm">
+                    {isEnglish ? badge.labelEn : badge.labelBn}
+                  </span>
+                ))}
               </div>
-              <h4 className="font-bold font-bengali mb-2 text-primary">বাংলায় শিক্ষা</h4>
-              <p className="font-bengali text-gray-600">
-                মাতৃভাষায় গভীর জ্ঞান অর্জন
+
+              <p className="mt-6 text-sm text-muted-foreground">
+                {isEnglish
+                  ? "Each enterprise deployment includes bilingual onboarding, governance workshops, and white-glove migration from legacy prompt repositories."
+                  : "প্রতিটি এন্টারপ্রাইজ ডিপ্লয়মেন্টে থাকে অনবোর্ডিং, গভর্নেন্স ওয়ার্কশপ এবং লেগেসি প্রম্পট রিপোজিটরি থেকে হোয়াইট-গ্লাভ মাইগ্রেশন।"}
               </p>
             </div>
-            <div className="text-center">
-              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-secondary/10 flex items-center justify-center">
-                <span className="text-2xl">💡</span>
-              </div>
-              <h4 className="font-bold font-bengali mb-2 text-secondary">দেশীয় উদাহরণ</h4>
-              <p className="font-bengali text-gray-600">
-                বাংলাদেশি প্রেক্ষাপটে ব্যবহারিক শিক্ষা
-              </p>
+          </div>
+
+          <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+            <div className="flex flex-wrap gap-2">
+              {enterpriseTracks.map((item) => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setActiveTrack(item.key)}
+                  className={`rounded-full px-4 py-2 text-sm font-semibold transition-all ${
+                    activeTrack === item.key
+                      ? "bg-primary text-white shadow-[var(--shadow-soft)]"
+                      : "bg-white text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  {isEnglish ? item.titleEn : item.titleBn}
+                </button>
+              ))}
             </div>
-            <div className="text-center">
-              <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-accent/10 flex items-center justify-center">
-                <span className="text-2xl">🤝</span>
+
+            <div className="mt-6 rounded-3xl border border-muted-foreground/20 bg-background/80 p-6 shadow-sm">
+              <div className="flex items-center gap-3">
+                <track.icon className="h-10 w-10 text-primary" />
+                <h3 className="text-lg font-semibold text-foreground">
+                  {isEnglish ? track.titleEn : track.titleBn}
+                </h3>
               </div>
-              <h4 className="font-bold font-bengali mb-2 text-accent">কমিউনিটি</h4>
-              <p className="font-bengali text-gray-600">
-                দেশব্যাপী সাপোর্ট নেটওয়ার্ক
+
+              <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+                {isEnglish ? track.descriptionEn : track.descriptionBn}
               </p>
+
+              <div className="mt-6 grid gap-3 text-sm text-muted-foreground">
+                {(isEnglish ? track.highlights : track.highlightsBn).map((highlight) => (
+                  <div key={highlight} className="rounded-2xl border border-muted-foreground/20 bg-white/80 p-3">
+                    <p className="text-foreground">{highlight}</p>
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/AdvancedPatterns.tsx
+++ b/src/components/AdvancedPatterns.tsx
@@ -1,67 +1,232 @@
+import { useMemo, useState } from "react";
+import { Globe2, Map, Search } from "lucide-react";
 
-import React from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Brain, Lightbulb, Target, Zap } from 'lucide-react';
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const industries = ["Marketing", "Finance", "Education", "Healthcare", "Media"] as const;
+const useCases = ["Campaign", "Insight", "Training", "Service", "Story"] as const;
+const models = ["GPT-4.1", "Claude 3", "Gemini Ultra"] as const;
+
+const marketplacePrompts = [
+  {
+    titleEn: "Dhaka retail festival narrative",
+    titleBn: "ঢাকা রিটেল উৎসব কাহিনি",
+    descriptionEn: "Localized storytelling prompt for launching seasonal retail campaigns across Bangladesh and diaspora hubs.",
+    descriptionBn: "বাংলাদেশ ও প্রবাসী বাজারে মৌসুমি রিটেল ক্যাম্পেইন চালু করার জন্য লোকালাইজড স্টোরিটেলিং প্রম্পট।",
+    industry: "Marketing" as const,
+    useCase: "Campaign" as const,
+    model: "GPT-4.1" as const,
+    region: "Dhaka • Toronto • Dubai",
+  },
+  {
+    titleEn: "Sharia-compliant SME finance advisor",
+    titleBn: "শরিয়াহ-সম্মত এসএমই ফাইন্যান্স উপদেষ্টা",
+    descriptionEn: "Conversational assistant that guides Bangladeshi SMEs through ethical financing instruments with regulatory context.",
+    descriptionBn: "বাংলাদেশি এসএমই-কে নৈতিক ফাইন্যান্সিং সমাধান বেছে নিতে সহায়তাকারী কথোপকথন-ভিত্তিক সহকারী, প্রাসঙ্গিক নীতিমালা সহ।",
+    industry: "Finance" as const,
+    useCase: "Service" as const,
+    model: "Claude 3" as const,
+    region: "Chattogram • Kuala Lumpur • Doha",
+  },
+  {
+    titleEn: "Heritage curriculum co-designer",
+    titleBn: "ঐতিহ্যবাহী কারিকুলাম সহ-ডিজাইনার",
+    descriptionEn: "Lesson co-pilot balancing Bengali literature with global STEM storytelling for blended classrooms.",
+    descriptionBn: "বাঙালি সাহিত্য ও গ্লোবাল STEM গল্পের ভারসাম্য রেখে ব্লেন্ডেড ক্লাসরুমের জন্য পাঠ পরিকল্পনা সহকারী।",
+    industry: "Education" as const,
+    useCase: "Training" as const,
+    model: "Gemini Ultra" as const,
+    region: "Sylhet • London • Singapore",
+  },
+  {
+    titleEn: "Cross-border telehealth navigator",
+    titleBn: "সীমান্ত-পার টেলিহেলথ নেভিগেটর",
+    descriptionEn: "Prompt suite enabling multilingual symptom triage with cultural nuance for caregivers across South Asia.",
+    descriptionBn: "দক্ষিণ এশিয়ার কেয়ারগিভারদের জন্য বহুভাষিক উপসর্গ মূল্যায়নে সাংস্কৃতিক প্রেক্ষাপট বজায় রাখা প্রম্পট সেট।",
+    industry: "Healthcare" as const,
+    useCase: "Service" as const,
+    model: "GPT-4.1" as const,
+    region: "Dhaka • Delhi • Riyadh",
+  },
+  {
+    titleEn: "Diaspora news personalization",
+    titleBn: "প্রবাসী সংবাদ ব্যক্তিগতকরণ",
+    descriptionEn: "Content orchestration for bilingual media rooms serving Bangladeshi audiences across 5 continents.",
+    descriptionBn: "পাঁচ মহাদেশে বিস্তৃত বাংলাদেশি শ্রোতাদের জন্য দ্বিভাষিক মিডিয়া রুমে কন্টেন্ট সংগঠনের প্রম্পট।",
+    industry: "Media" as const,
+    useCase: "Insight" as const,
+    model: "Claude 3" as const,
+    region: "New York • Sydney • Dhaka",
+  },
+];
 
 const AdvancedPatterns = () => {
-  const patterns = [
-    {
-      icon: Brain,
-      title: 'চেইন অফ থট প্রম্পটিং',
-      description: 'ধাপে ধাপে চিন্তা প্রক্রিয়া দিয়ে জটিল সমস্যার সমাধান',
-      example: 'আমি এই সমস্যাটি ধাপে ধাপে সমাধান করব...'
-    },
-    {
-      icon: Target,
-      title: 'ফিউ-শট লার্নিং',
-      description: 'কয়েকটি উদাহরণ দিয়ে AI কে শেখানোর কৌশল',
-      example: 'এখানে ৩টি উদাহরণ: 1. ... 2. ... 3. ...'
-    },
-    {
-      icon: Lightbulb,
-      title: 'রোল প্লেয়িং প্রম্পট',
-      description: 'AI কে নির্দিষ্ট ভূমিকায় অভিনয় করতে বলা',
-      example: 'আপনি একজন বিশেষজ্ঞ শিক্ষক হিসেবে...'
-    },
-    {
-      icon: Zap,
-      title: 'টেমপ্লেট বেসড প্রম্পট',
-      description: 'পুনরায় ব্যবহারযোগ্য প্রম্পট টেমপ্লেট তৈরি',
-      example: '[প্রসঙ্গ] + [কাজ] + [ফরম্যাট] + [শর্ত]'
-    }
-  ];
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  const [search, setSearch] = useState("");
+  const [industryFilter, setIndustryFilter] = useState<(typeof industries)[number] | "All">("All");
+  const [useCaseFilter, setUseCaseFilter] = useState<(typeof useCases)[number] | "All">("All");
+  const [modelFilter, setModelFilter] = useState<(typeof models)[number] | "All">("All");
+
+  const filteredPrompts = useMemo(() => {
+    return marketplacePrompts.filter((prompt) => {
+      const matchesSearch = `${prompt.titleEn} ${prompt.titleBn} ${prompt.descriptionEn} ${prompt.descriptionBn}`
+        .toLowerCase()
+        .includes(search.toLowerCase());
+      const matchesIndustry = industryFilter === "All" || prompt.industry === industryFilter;
+      const matchesUseCase = useCaseFilter === "All" || prompt.useCase === useCaseFilter;
+      const matchesModel = modelFilter === "All" || prompt.model === modelFilter;
+      return matchesSearch && matchesIndustry && matchesUseCase && matchesModel;
+    });
+  }, [industryFilter, modelFilter, search, useCaseFilter]);
+
+  const renderFilterGroup = <T extends string>(
+    labelEn: string,
+    labelBn: string,
+    options: readonly T[],
+    active: T | "All",
+    onSelect: (value: T | "All") => void,
+  ) => {
+    const label = isEnglish ? labelEn : labelBn;
+    const allLabel = isEnglish ? "All" : "সকল";
+
+    return (
+      <div className="space-y-3">
+        <p className="text-sm font-semibold text-muted-foreground">{label}</p>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+              active === "All"
+                ? "border-transparent bg-primary text-white shadow-sm"
+                : "border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/60 hover:text-foreground"
+            }`}
+            onClick={() => onSelect("All")}
+          >
+            {allLabel}
+          </button>
+          {options.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={`rounded-full border px-3 py-1.5 text-sm font-medium transition-colors ${
+                active === option
+                  ? "border-transparent bg-primary text-white shadow-sm"
+                  : "border-muted-foreground/30 text-muted-foreground hover:border-muted-foreground/60 hover:text-foreground"
+              }`}
+              onClick={() => onSelect(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  };
 
   return (
-    <section id="advanced-patterns" className="py-20 bg-gradient-to-b from-blue-50 to-white">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl font-bold font-bengali text-gray-900 mb-4">
-            উন্নত প্রম্পট প্যাটার্ন
-          </h2>
-          <p className="text-xl text-gray-600 font-bengali max-w-3xl mx-auto">
-            প্রফেশনাল লেভেলের প্রম্পট ইঞ্জিনিয়ারিং কৌশল শিখুন
-          </p>
+    <section id="marketplace" className="section bg-gradient-to-b from-white to-primary/5">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid gap-16 lg:grid-cols-[1fr_1.1fr]">
+          <div className="space-y-6">
+            <p className="section-eyebrow">{isEnglish ? "Marketplace Explorer" : "মার্কেটপ্লেস এক্সপ্লোরার"}</p>
+            <h2 className="section-heading">
+              {isEnglish
+                ? "Discover 42,000+ culturally fluent prompts."
+                : "৪২,০০০+ সাংস্কৃতিকভাবে প্রাসঙ্গিক প্রম্পট আবিষ্কার করুন।"}
+            </h2>
+            <p className="section-subheading">
+              {isEnglish
+                ? "Filter by industry, use case, and foundation model to curate the perfect prompt stack. Every listing is verified for linguistic nuance, brand safety, and enterprise readiness."
+                : "ইন্ডাস্ট্রি, ইউজ কেস ও মডেল অনুযায়ী ফিল্টার করে আপনার প্রয়োজন অনুযায়ী প্রম্পট বাছাই করুন। প্রতিটি লিস্টিং ভাষার সূক্ষ্মতা, ব্র্যান্ড সেফটি ও এন্টারপ্রাইজ মান যাচাই করা।"}
+            </p>
+
+            <div className="grid gap-4 rounded-3xl border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                <Globe2 className="h-5 w-5 text-primary" />
+                <span className="font-semibold text-foreground">
+                  {isEnglish ? "Bengali-first, global reach" : "বাংলা-প্রথম, গ্লোবাল উপস্থিতি"}
+                </span>
+                <span className="text-muted-foreground/70">•</span>
+                <span>
+                  {isEnglish
+                    ? "EN | বাংলা side-by-side copy for teams."
+                    : "টিমের জন্য EN | বাংলা পাশাপাশির কপি।"}
+                </span>
+                <span className="text-muted-foreground/70">•</span>
+                <span className="text-foreground">
+                  {isEnglish ? "ISO 27001 & GDPR alignment" : "ISO 27001 ও GDPR সমন্বয়"}
+                </span>
+              </div>
+              <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                <Map className="h-5 w-5 text-secondary" />
+                <span>
+                  {isEnglish
+                    ? "Localized tags: Dhaka, Singapore, Dubai, Lagos, New York"
+                    : "লোকালাইজড ট্যাগ: ঢাকা, সিঙ্গাপুর, দুবাই, লাগোস, নিউ ইয়র্ক"}
+                </span>
+              </div>
+            </div>
+          </div>
+
+          <div className="glass-panel rounded-[2rem] p-8">
+            <div className="mb-6 flex items-center gap-3 rounded-2xl border border-muted-foreground/20 bg-background/60 px-4 py-3">
+              <Search className="h-5 w-5 text-primary" />
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder={
+                  isEnglish
+                    ? "Search prompts by industry, tone, or model…"
+                    : "ইন্ডাস্ট্রি, টোন বা মডেল দিয়ে প্রম্পট খুঁজুন…"
+                }
+                className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+              />
+            </div>
+
+            <div className="space-y-8">
+              {renderFilterGroup("Industry", "ইন্ডাস্ট্রি", industries, industryFilter, setIndustryFilter)}
+              {renderFilterGroup("Use Case", "ইউজ কেস", useCases, useCaseFilter, setUseCaseFilter)}
+              {renderFilterGroup("Model", "মডেল", models, modelFilter, setModelFilter)}
+            </div>
+          </div>
         </div>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
-          {patterns.map((pattern, index) => (
-            <Card key={index} className="hover:shadow-xl transition-shadow duration-300">
-              <CardHeader className="text-center">
-                <pattern.icon className="w-12 h-12 text-blue-600 mx-auto mb-4" />
-                <CardTitle className="font-bengali text-lg">{pattern.title}</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="font-bengali text-center mb-4">
-                  {pattern.description}
-                </CardDescription>
-                <div className="bg-gray-100 p-3 rounded-lg">
-                  <p className="text-sm font-bengali text-gray-700 italic">
-                    "{pattern.example}"
-                  </p>
-                </div>
-              </CardContent>
-            </Card>
+        <div className="mt-16 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {filteredPrompts.map((prompt) => (
+            <div key={prompt.titleEn} className="glass-panel flex h-full flex-col gap-4 rounded-3xl p-6">
+              <div>
+                <h3 className="text-lg font-semibold text-foreground">
+                  {isEnglish ? prompt.titleEn : prompt.titleBn}
+                </h3>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  {isEnglish ? prompt.descriptionEn : prompt.descriptionBn}
+                </p>
+              </div>
+              <div className="mt-auto flex flex-wrap items-center gap-3 text-xs font-medium uppercase tracking-[0.2em] text-muted-foreground">
+                <span className="rounded-full bg-primary/10 px-3 py-1 text-primary">{prompt.industry}</span>
+                <span className="rounded-full bg-secondary/20 px-3 py-1 text-secondary">{prompt.useCase}</span>
+                <span className="rounded-full bg-accent/15 px-3 py-1 text-accent">{prompt.model}</span>
+                <span className="rounded-full border border-muted-foreground/30 px-3 py-1 text-muted-foreground">
+                  {prompt.region}
+                </span>
+              </div>
+            </div>
           ))}
+
+          {filteredPrompts.length === 0 && (
+            <div className="col-span-full rounded-3xl border border-dashed border-muted-foreground/30 bg-white/70 p-10 text-center text-sm text-muted-foreground">
+              <p className="font-semibold text-foreground">
+                {isEnglish ? "No prompts match your filters yet." : "আপনার নির্বাচিত ফিল্টারে কোনো প্রম্পট নেই।"}
+              </p>
+              <p className="mt-2">
+                {isEnglish
+                  ? "Adjust your filters to explore more curated listings."
+                  : "ফিল্টার পরিবর্তন করে আরও কিউরেটেড লিস্টিং দেখুন।"}
+              </p>
+            </div>
+          )}
         </div>
       </div>
     </section>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -3,18 +3,21 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Mail, Phone, MapPin, Send } from "lucide-react";
+import { Mail, MapPin, Send, Headset } from "lucide-react";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { useRateLimit } from "@/hooks/useRateLimit";
 import { createScopedLogger } from "@/lib/logger";
+import { useLanguage } from "@/contexts/LanguageContext";
 
-const RATE_LIMIT_WINDOW = 15 * 60 * 1000; // 15 minutes
+const RATE_LIMIT_WINDOW = 15 * 60 * 1000;
 const RATE_LIMIT_ATTEMPTS = 3;
 
 const contactLogger = createScopedLogger("contact-form");
 
 const Contact = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
   const [formData, setFormData] = useState({
     name: "",
     email: "",
@@ -36,12 +39,14 @@ const Contact = () => {
     };
   }, []);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
     if (loading) return;
 
     if (!navigator.onLine) {
-      toast.error("ইন্টারনেট সংযোগ নেই। পরে আবার চেষ্টা করুন।");
+      toast.error(
+        isEnglish ? "No internet connection. Please try again later." : "ইন্টারনেট সংযোগ নেই। পরে আবার চেষ্টা করুন।",
+      );
       return;
     }
 
@@ -49,9 +54,10 @@ const Contact = () => {
       const waitMs = Math.max(resetTime - Date.now(), 0);
       const waitMinutes = Math.ceil(waitMs / 60000);
       const attemptsLeft = Math.max(remainingAttempts, 0);
-      toast.warning(
-        `আপনি বার্তা পাঠানোর সীমা অতিক্রম করেছেন। ${waitMinutes} মিনিট পরে আবার চেষ্টা করুন। (${attemptsLeft} প্রচেষ্টা বাকি)`
-      );
+      const warningMessage = isEnglish
+        ? `You've reached the submission limit. Try again in ${waitMinutes} minute(s). (${attemptsLeft} attempts left)`
+        : `আপনি বার্তা পাঠানোর সীমা অতিক্রম করেছেন। ${waitMinutes} মিনিট পরে আবার চেষ্টা করুন। (${attemptsLeft} প্রচেষ্টা বাকি)`;
+      toast.warning(warningMessage);
       return;
     }
 
@@ -66,11 +72,13 @@ const Contact = () => {
         throw error;
       }
 
-      toast.success("আপনার বার্তা সফলভাবে পাঠানো হয়েছে!");
+      toast.success(isEnglish ? "Your message has been sent!" : "আপনার বার্তা সফলভাবে পাঠানো হয়েছে!");
       setFormData({ name: "", email: "", subject: "", message: "" });
     } catch (error: unknown) {
       contactLogger.error("Error sending contact form message", { error });
-      toast.error("বার্তা পাঠাতে সমস্যা হয়েছে। অনুগ্রহ করে আবার চেষ্টা করুন।");
+      toast.error(
+        isEnglish ? "We couldn’t send your message. Please try again." : "বার্তা পাঠাতে সমস্যা হয়েছে। অনুগ্রহ করে আবার চেষ্টা করুন।",
+      );
     } finally {
       if (isMountedRef.current) {
         setLoading(false);
@@ -78,8 +86,8 @@ const Contact = () => {
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    const { name, value } = e.target;
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
     setFormData((prev) => ({
       ...prev,
       [name]: value,
@@ -87,106 +95,128 @@ const Contact = () => {
   };
 
   return (
-    <section id="contact" className="py-20 bangladesh-pattern">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 text-primary rounded-full mb-6 border border-primary/20">
-            <span className="text-xl">📞</span>
-            <span className="font-bengali font-medium">আমাদের সাথে থাকুন</span>
-          </div>
-          <h2 className="text-4xl font-bold font-display text-gray-900 mb-4">
-            যোগাযোগ করুন
-          </h2>
-          <p className="text-xl text-gray-600 font-bengali max-w-3xl mx-auto leading-relaxed">
-            আপনার AI শেখার যাত্রায় আমরা সবসময় পাশে আছি
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-12">
-          <div>
-            <h3 className="text-2xl font-bold font-bengali text-gray-900 mb-6">
-              আমাদের সাথে যোগাযোগ করুন
-            </h3>
-            <p className="text-lg font-bengali text-gray-700 mb-6 leading-relaxed">
-              আপনার কোন প্রশ্ন, পরামর্শ বা সহযোগিতার প্রয়োজন হলে আমাদের জানান। 
-              বাংলাদেশের AI শিক্ষার ভবিষ্যৎ গড়তে আমরা সবসময় আপনার পাশে।
+    <section id="support" className="section bg-gradient-to-b from-background to-primary/10">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid gap-14 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-8">
+            <p className="section-eyebrow">{isEnglish ? "Global Support" : "গ্লোবাল সাপোর্ট"}</p>
+            <h2 className="section-heading">
+              {isEnglish
+                ? "Concierge for creators and enterprises."
+                : "ক্রিয়েটর ও এন্টারপ্রাইজের জন্য কনসিয়ার্জ সহায়তা।"}
+            </h2>
+            <p className="section-subheading">
+              {isEnglish
+                ? "Our bilingual strategy desk guides licensing, go-to-market localisation, and enterprise integrations with measurable precision."
+                : "লাইসেন্সিং নির্দেশনা, গো-টু-মার্কেট লোকালাইজেশন ও এন্টারপ্রাইজ ইন্টিগ্রেশন—সবকিছুতেই পরিমিত নির্ভুলতা নিয়ে আমাদের দ্বিভাষিক স্ট্র্যাটেজি ডেস্ক পাশে আছে।"}
             </p>
 
-            <div className="space-y-6">
-              <div className="flex items-center space-x-4">
-                <Mail className="w-6 h-6 text-blue-600" />
+            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex items-center gap-3">
+                <Headset className="h-6 w-6 text-primary" />
                 <div>
-                  <h4 className="font-semibold font-bengali">ইমেইল</h4>
-                  <p className="text-gray-600">abir.abbas@proton.me</p>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isEnglish ? "Response in under 12 hours" : "১২ ঘণ্টার মধ্যে সাড়া"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {isEnglish ? "Priority queue for verified partners" : "যাচাইকৃত পার্টনারদের জন্য অগ্রাধিকার"}
+                  </p>
                 </div>
               </div>
-              <div className="flex items-center space-x-4">
-                <Phone className="w-6 h-6 text-blue-600" />
-                <div>
-                  <h4 className="font-semibold font-bengali">ফোন</h4>
-                  <p className="text-gray-600">+৮৮০১৮৪১৬০৩৫৪২</p>
+              <div className="mt-4 grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+                <div className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <p className="text-foreground font-semibold">
+                    {isEnglish ? "Enterprise Hotline" : "এন্টারপ্রাইজ হটলাইন"}
+                  </p>
+                  <p>+880 1841 603 542</p>
+                  <p className="text-muted-foreground">
+                    {isEnglish ? "72h onboarding guarantee" : "৭২ ঘণ্টায় অনবোর্ডিং নিশ্চয়তা"}
+                  </p>
+                </div>
+                <div className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <p className="text-foreground font-semibold">
+                    {isEnglish ? "Creator Success" : "ক্রিয়েটর সাকসেস"}
+                  </p>
+                  <p>creators@banglaprompt.ai</p>
+                  <p className="text-muted-foreground">
+                    {isEnglish ? "Guides, payouts, strategy" : "গাইড, পেআউট, স্ট্র্যাটেজি"}
+                  </p>
                 </div>
               </div>
-              <div className="flex items-center space-x-4">
-                <MapPin className="w-6 h-6 text-blue-600" />
-                <div>
-                  <h4 className="font-semibold font-bengali">ঠিকানা</h4>
-                  <p className="text-gray-600">ঢাকা, বাংলাদেশ</p>
-                </div>
+            </div>
+
+            <div className="grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+              <div className="rounded-2xl border border-muted-foreground/20 bg-white/80 p-4 shadow-sm">
+                <Mail className="mb-2 h-5 w-5 text-primary" />
+                <p className="font-semibold text-foreground">abir.abbas@proton.me</p>
+                <p>{isEnglish ? "Primary strategic liaison" : "প্রধান কৌশলগত যোগাযোগ"}</p>
+              </div>
+              <div className="rounded-2xl border border-muted-foreground/20 bg-white/80 p-4 shadow-sm">
+                <MapPin className="mb-2 h-5 w-5 text-secondary" />
+                <p className="font-semibold text-foreground">Dhaka • Singapore • New York</p>
+                <p>{isEnglish ? "Hybrid coverage model" : "হাইব্রিড কাভারেজ মডেল"}</p>
               </div>
             </div>
           </div>
 
-          <Card className="cultural-card border-primary/20">
+          <Card className="rounded-[2rem] border border-white/60 bg-white/90 shadow-[var(--shadow-soft)] backdrop-blur">
             <CardHeader>
-              <CardTitle className="font-bengali">মেসেজ পাঠান</CardTitle>
-              <CardDescription className="font-bengali">
-                আমরা যত দ্রুত সম্ভব আপনার সাথে যোগাযোগ করব
+              <CardTitle className="text-xl font-semibold text-foreground">
+                {isEnglish ? "Partner with BanglaPrompt.ai" : "BanglaPrompt.ai-এর সাথে পার্টনার হোন"}
+              </CardTitle>
+              <CardDescription className="text-sm text-muted-foreground">
+                {isEnglish
+                  ? "Share your goal—we’ll orchestrate the right prompts, governance, and go-live runway."
+                  : "আপনার লক্ষ্য জানান—সঠিক প্রম্পট, গভর্নেন্স ও গো-লাইভ সাপোর্ট আমরা নিশ্চিত করব।"}
               </CardDescription>
             </CardHeader>
             <CardContent>
               <form onSubmit={handleSubmit} className="space-y-4">
-                <div>
+                <div className="grid gap-4 md:grid-cols-2">
                   <Input
                     name="name"
-                    placeholder="আপনার নাম"
+                    placeholder={isEnglish ? "Name" : "নাম"}
                     value={formData.name}
                     onChange={handleChange}
                     required
                   />
-                </div>
-                <div>
                   <Input
                     name="email"
                     type="email"
-                    placeholder="আপনার ইমেইল"
+                    placeholder={isEnglish ? "Work email" : "কর্মস্থলের ইমেইল"}
                     value={formData.email}
                     onChange={handleChange}
                     required
                   />
                 </div>
-                <div>
-                  <Input
-                    name="subject"
-                    placeholder="বিষয়"
-                    value={formData.subject}
-                    onChange={handleChange}
-                    required
-                  />
-                </div>
-                <div>
-                  <Textarea
-                    name="message"
-                    placeholder="আপনার বার্তা লিখুন..."
-                    rows={5}
-                    value={formData.message}
-                    onChange={handleChange}
-                    required
-                  />
-                </div>
-                <Button type="submit" className="w-full" disabled={loading}>
-                  <Send className="w-4 h-4 mr-2" />
-                  {loading ? 'পাঠানো হচ্ছে...' : 'বার্তা পাঠান'}
+                <Input
+                  name="subject"
+                  placeholder={isEnglish ? "Project focus" : "প্রকল্পের বিষয়"}
+                  value={formData.subject}
+                  onChange={handleChange}
+                  required
+                />
+                <Textarea
+                  name="message"
+                  placeholder={isEnglish ? "Tell us about your goals" : "আপনার লক্ষ্য সম্পর্কে বলুন"}
+                  rows={5}
+                  value={formData.message}
+                  onChange={handleChange}
+                  required
+                />
+                <Button
+                  type="submit"
+                  className="w-full rounded-full bg-[var(--gradient-aurora)] text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+                  disabled={loading}
+                >
+                  <Send className="mr-2 h-4 w-4" />
+                  {loading
+                    ? isEnglish
+                      ? "Sending..."
+                      : "পাঠানো হচ্ছে..."
+                    : isEnglish
+                      ? "Start the conversation"
+                      : "বার্তা পাঠান"}
                 </Button>
               </form>
             </CardContent>

--- a/src/components/EnvironmentDebug.tsx
+++ b/src/components/EnvironmentDebug.tsx
@@ -20,7 +20,7 @@ const EnvironmentDebug: React.FC<EnvironmentDebugProps> = ({
 
       // Check browser injected env
       try {
-        const browserEnv = (globalThis as any).__ENV__;
+        const browserEnv = (globalThis as { __ENV__?: Record<string, unknown> }).__ENV__;
         info.browserEnv = browserEnv ? Object.keys(browserEnv) : 'Not available';
         info.supabaseUrl = browserEnv?.SUPABASE_URL ? 'Available' : 'Missing';
         info.supabaseKey = browserEnv?.SUPABASE_ANON_KEY ? 'Available' : 'Missing';

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,181 +1,69 @@
+import { Lightbulb, ShieldCheck, Sparkle } from "lucide-react";
+import { useLanguage } from "@/contexts/LanguageContext";
 
-import FeatureCard from "./FeatureCard";
+const pillars = [
+  {
+    icon: Sparkle,
+    titleEn: "Built for Bengali Creators",
+    titleBn: "বাংলা নির্মাতাদের জন্য নির্মিত",
+    descriptionEn: "Earn globally with prompts tuned to Bengali idioms, festivals, and heritage while staying performance-ready for GPT-4.1, Claude 3, and Gemini Ultra.",
+    descriptionBn: "বাংলা বাগধারা, উৎসব ও ঐতিহ্যকে কেন্দ্র করে প্রম্পট তৈরি করে বিশ্বজুড়ে আয় করুন—GPT-4.1, Claude 3, Gemini Ultra-র জন্য অপ্টিমাইজড।",
+  },
+  {
+    icon: ShieldCheck,
+    titleEn: "Fair & Transparent Revenue",
+    titleBn: "ন্যায্য ও স্বচ্ছ আয়",
+    descriptionEn: "Keep up to 80% per sale, monitor predictive royalties, and access a 72-hour payout promise backed by compliance reporting.",
+    descriptionBn: "প্রতি বিক্রয়ে ৮০% পর্যন্ত আয় রাখুন, প্রেডিক্টিভ রয়্যালটি ট্র্যাক করুন এবং কমপ্লায়েন্স রিপোর্টসহ ৭২ ঘণ্টায় পেমেন্ট পান।",
+  },
+  {
+    icon: Lightbulb,
+    titleEn: "Global Demand Engine",
+    titleBn: "গ্লোবাল ডিমান্ড ইঞ্জিন",
+    descriptionEn: "Surface on dashboards used by Fortune 500 teams with localized curation, audit trails, and shared analytics hubs.",
+    descriptionBn: "লোকালাইজড কিউরেশন, অডিট ট্রেইল ও শেয়ারড অ্যানালিটিক্স হাবের মাধ্যমে Fortune 500 টিমের সামনে আপনার প্রম্পট পৌঁছে দিন।",
+  },
+];
 
 const Features = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
   return (
-    <section id="features" className="section bg-gray-50 py-20">
-      <div className="container mx-auto px-4 md:px-6">
-        <div className="text-center max-w-3xl mx-auto mb-16">
-          <h2 className="text-3xl md:text-4xl font-bold mb-4">
-            <span className="highlight-text">ফ্রি প্রম্পট ইঞ্জিনিয়ারিং</span> গাইড
+    <section id="value" className="section relative">
+      <div className="pointer-events-none absolute inset-0 bg-gradient-to-b from-transparent via-primary/5 to-transparent" />
+      <div className="relative mx-auto max-w-7xl px-4 md:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="section-eyebrow">Creator Economy 2025</p>
+          <h2 className="section-heading">
+            {isEnglish ? "Fortune 500 confidence. Bengali soul." : "ফর্চুন ৫০০ মানের নিশ্চয়তা। বাঙালি আবেগের সুর।"}
           </h2>
-          <p className="text-muted-foreground text-lg">
-            বাংলায় অত্যন্ত বিস্তারিত উদাহরণ সহ প্রম্পট ইঞ্জিনিয়ারিং শিখুন
+          <p className="section-subheading mx-auto mt-6">
+            {isEnglish
+              ? "Human-centred prompt commerce keeps Bengali creativity visible while packaging revenue clarity, governance, and accessibility for enterprise teams."
+              : "মানব-কেন্দ্রিক প্রম্পট কমার্স বাংলা সৃজনশীলতাকে সামনে আনে, একই সাথে এন্টারপ্রাইজ টিমের জন্য স্বচ্ছ আয়, গভর্নেন্স ও অ্যাক্সেসিবিলিটি নিশ্চিত করে।"}
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-          <FeatureCard
-            title="বেসিক প্রম্পট রাইটিং"
-            description="সাধারণ প্রম্পট লেখার মৌলিক কৌশল এবং নিয়ম"
-            example={`উদাহরণ: "আমাকে বাংলায় একটি ছোট গল্প বলো যেটি শিশুদের উপযোগী এবং নৈতিক শিক্ষা দেয়।"\n\nবিশ্লেষণ: এই প্রম্পটে নির্দিষ্ট করে বলা হয়েছে (১) ভাষা: বাংলা, (২) বিষয়: শিশুদের উপযোগী গল্প, (৩) উদ্দেশ্য: নৈতিক শিক্ষা দেওয়া।`}
-            promptTips={[
-              "সরল ও স্পষ্ট ভাষা ব্যবহার করুন",
-              "আপনি কী চান তা নির্দিষ্ট করে বলুন",
-              "প্রসঙ্গ দিন যেখানে প্রয়োজন"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-blue-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
-                />
-              </svg>
-            }
-            iconClassName="bg-blue-500/10"
-          />
-
-          <FeatureCard
-            title="ডিটেলড প্রম্পট টেকনিক"
-            description="বিস্তারিত এবং কার্যকরী প্রম্পট লেখার কৌশল"
-            example={`উদাহরণ: "তুমি একজন SEO বিশেষজ্ঞ। আমি একটি ফুলের দোকানের জন্য ওয়েবসাইট বানাচ্ছি। আমাকে ১০টি SEO-ফ্রেন্ডলি কিওয়ার্ড দাও যা বাংলাদেশে ফুলের দোকানের জন্য সবচেয়ে বেশি সার্চ করা হয়, এবং প্রতিটি কিওয়ার্ডের জন্য বাংলায় একটি ছোট ব্লগ পোস্টের শিরোনাম সাজেস্ট করো।"\n\nবিশ্লেষণ: এই প্রম্পটে এআই-কে একটি নির্দিষ্ট ভূমিকা দেওয়া হয়েছে (SEO বিশেষজ্ঞ), প্রসঙ্গ দেওয়া হয়েছে (ফুলের দোকানের ওয়েবসাইট), এবং সুনির্দিষ্ট আউটপুট চাওয়া হয়েছে (১০টি কিওয়ার্ড এবং ব্লগ শিরোনাম)।`}
-            promptTips={[
-              "এআই-কে একটি নির্দিষ্ট ভূমিকা দিন",
-              "প্রসঙ্গ ও পটভূমি বিবরণ দিন",
-              "আউটপুটের ফর্ম্যাট নির্দিষ্ট করে বলুন"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-violet-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
-                />
-              </svg>
-            }
-            iconClassName="bg-violet-500/10"
-          />
-
-          <FeatureCard
-            title="সৃজনশীল লেখনী"
-            description="এআই-এর সাহায্যে সৃজনশীল লেখার কৌশল"
-            example={`উদাহরণ: "তুমি একজন অভিজ্ঞ গল্প লেখক। এই প্লটে ভিত্তি করে একটি ছোট গল্প লেখো: একটি ভবিষ্যতের দুনিয়ায়, যেখানে মানুষ তাদের স্মৃতি বিক্রি করতে পারে, একজন যুবক তার প্রথম প্রেমের স্মৃতি বিক্রি করার সিদ্ধান্ত নেয়। গল্পটি লেখার সময় বিশেষ মনোযোগ দাও: অনুভূতি, আবেগ, পরিবেশের বর্ণনা, চরিত্রের মনোজগৎ। গল্পের শেষে একটি মোড় থাকুক যা পাঠককে ভাবতে বাধ্য করবে।"\n\nবিশ্লেষণ: এই প্রম্পটে শুধু গল্পের প্লট নয়, লেখার স্টাইল ও ফোকাস পয়েন্টও নির্দিষ্ট করে দেওয়া হয়েছে, যা এআই-কে আরও সুনির্দিষ্ট আউটপুট তৈরি করতে সাহায্য করে।`}
-            promptTips={[
-              "সৃজনশীল প্রম্পটে স্পেসিফিক নির্দেশনা দিন",
-              "টোন, পরিবেশ, ও স্টাইল নির্দেশ করুন",
-              "মুড ও আবেগ সম্পর্কে উল্লেখ করুন"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-pink-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                />
-              </svg>
-            }
-            iconClassName="bg-pink-500/10"
-          />
-
-          <FeatureCard
-            title="কোডিং প্রম্পট"
-            description="প্রোগ্রামিং এবং কোডিং সমস্যা সমাধানের জন্য প্রম্পট"
-            example={`উদাহরণ: "আমি React.js শিখছি। আমাকে একটি প্রোডাক্ট লিস্টিং পেজ বানাতে সাহায্য করো যেখানে JSON এপিআই থেকে ডাটা লোড হবে। কম্পোনেন্টগুলো ভাগ করে দেখাও: একটি ProductList কম্পোনেন্ট, একটি ProductCard কম্পোনেন্ট, এবং ডাটা ফেচিং লজিক। প্রতিটি কম্পোনেন্টের কোড বাংলায় কমেন্ট সহ দেখাও এবং পুরো কোডটি কিভাবে একসাথে কাজ করে তা ব্যাখ্যা করো।"\n\nবিশ্লেষণ: এই প্রম্পটে স্পষ্টভাবে নির্দিষ্ট করা হয়েছে (১) টেকনোলজি: React.js, (২) উদ্দেশ্য: প্রোডাক্ট লিস্টিং পেজ, (৩) কোড ফর্ম্যাট: আলাদা কম্পোনেন্ট, (৪) অতিরিক্ত আবশ্যকতা: বাংলা কমেন্ট ও ব্যাখ্যা।`}
-            promptTips={[
-              "কোন প্রোগ্রামিং ল্যাঙ্গুয়েজ ব্যবহার করবেন তা নির্দিষ্ট করুন",
-              "কোডের উদ্দেশ্য ও কার্যকারিতা স্পষ্ট করুন",
-              "কোড ফর্ম্যাট ও স্টাইল সম্পর্কে নির্দেশনা দিন"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-green-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                />
-              </svg>
-            }
-            iconClassName="bg-green-500/10"
-          />
-
-          <FeatureCard
-            title="চেইন প্রম্পটিং"
-            description="একাধিক প্রম্পট দিয়ে জটিল কাজ সম্পাদন করা"
-            example={`প্রথম প্রম্পট: "আমি একটি ই-কমার্স ওয়েবসাইট বানাচ্ছি। এই ওয়েবসাইটে কী কী ফিচার থাকা উচিত তার একটি তালিকা তৈরি করো।"\n\nএআই উত্তর দেওয়ার পর দ্বিতীয় প্রম্পট: "এই ফিচারগুলো বাস্তবায়ন করার জন্য আমার কী কী টেকনোলজি লাগবে? প্রতিটি ফিচারের জন্য সুপারিশকৃত টেকনোলজি উল্লেখ করো।"\n\nতৃতীয় প্রম্পট: "এখন আমাকে প্রথম ফেজে কোন কোন ফিচার বাস্তবায়ন করা উচিত এবং কোন কোন ফিচার পরবর্তী ফেজের জন্য রাখা উচিত, তার একটি রোডম্যাপ তৈরি করে দাও।"\n\nবিশ্লেষণ: এই চেইন প্রম্পটিং পদ্ধতিতে, প্রতিটি পরবর্তী প্রম্পট আগের প্রম্পটের উত্তরের উপর ভিত্তি করে তৈরি করা হয়, যা জটিল কাজকে ছোট ছোট ধাপে ভাগ করে সমাধান করতে সাহায্য করে।`}
-            promptTips={[
-              "বড় সমস্যাকে ছোট ছোট পর্যায়ে ভাগ করুন",
-              "প্রতিটি পরবর্তী প্রম্পট আগের উত্তরের উপর ভিত্তি করে তৈরি করুন",
-              "প্রতিটি ধাপে উত্তরগুলো পরীক্ষা করে দেখুন"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-orange-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"
-                />
-              </svg>
-            }
-            iconClassName="bg-orange-500/10"
-          />
-
-          <FeatureCard
-            title="ইমেজ জেনারেশন প্রম্পট"
-            description="Midjourney, DALL-E, Stable Diffusion এর জন্য প্রম্পট"
-            example={`উদাহরণ: "একটি ফটোরিয়ালিস্টিক ছবি তৈরি করো: বাংলাদেশের গ্রামীণ পরিবেশে সূর্যাস্ত, শান্ত নদী, সবুজ ধানক্ষেত, দূরে কয়েকটি খড়ের ঘর, হালকা কুয়াশা, রোমান্টিক আলো, উচ্চ রেজলিউশন, ডিটেইলড টেক্সচার, সিনেমাটিক লাইটিং।"\n\nবিশ্লেষণ: এই প্রম্পটে ছবির প্রধান বিষয় (গ্রামীণ দৃশ্য), মূড (শান্ত, রোমান্টিক), পরিবেশগত উপাদান (নদী, ধানক্ষেত, খড়ের ঘর), টেকনিকাল স্পেসিফিকেশন (উচ্চ রেজলিউশন), এবং স্টাইল (সিনেমাটিক লাইটিং) নির্দিষ্ট করে দেওয়া হয়েছে।`}
-            promptTips={[
-              "ছবির মূল বিষয়বস্তু স্পষ্টভাবে উল্লেখ করুন",
-              "পরিবেশ, আলো, মেজাজ ও স্টাইল বর্ণনা করুন",
-              "টেকনিকাল বিবরণ দিন (রেজলিউশন, ডিটেইল, ইত্যাদি)"
-            ]}
-            icon={
-              <svg
-                className="w-6 h-6 text-teal-500"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                />
-              </svg>
-            }
-            iconClassName="bg-teal-500/10"
-          />
+        <div className="mt-16 grid gap-8 md:grid-cols-3">
+          {pillars.map((pillar) => (
+            <div
+              key={pillar.titleEn}
+              className="glass-panel flex h-full flex-col gap-4 rounded-3xl p-8 text-left"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/15 text-primary">
+                <pillar.icon className="h-5 w-5" />
+              </div>
+              <div className="space-y-2">
+                <h3 className="text-xl font-semibold text-foreground">
+                  {isEnglish ? pillar.titleEn : pillar.titleBn}
+                </h3>
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {isEnglish ? pillar.descriptionEn : pillar.descriptionBn}
+                </p>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -1,0 +1,87 @@
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const FinalCTA = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <section id="cta" className="py-20">
+      <div className="mx-auto max-w-6xl px-4 md:px-8">
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-white/60 bg-[var(--gradient-midnight)] px-8 py-12 text-white shadow-[var(--shadow-elevated)] md:px-16 md:py-16">
+          <div className="absolute -right-24 top-[-6rem] h-72 w-72 rounded-full bg-secondary/40 blur-3xl" />
+          <div className="absolute -left-24 bottom-[-8rem] h-72 w-72 rounded-full bg-primary/40 blur-3xl" />
+
+          <div className="relative grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-4">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+                {isEnglish ? "Start today" : "এখনই শুরু করুন"}
+              </p>
+              <h2 className="text-3xl font-semibold md:text-4xl lg:text-5xl">
+                {isEnglish ? "Shape the future of AI creation." : "এআই সৃজনশীলতার ভবিষ্যৎ গড়ুন।"}
+              </h2>
+              <p className="text-sm leading-relaxed text-white/80 md:text-base">
+                {isEnglish
+                  ? "Join the Bengali-first prompt commerce network built for modern creators and enterprise buyers. We streamline monetisation, licensing, and compliance so you can focus on crafting high-impact prompts."
+                  : "আধুনিক নির্মাতা ও এন্টারপ্রাইজ ক্রেতাদের জন্য নির্মিত বাঙালি প্রম্পট কমার্স নেটওয়ার্কে যোগ দিন। আয়, লাইসেন্সিং ও কমপ্লায়েন্স আমরা সামলাই—আপনি উচ্চমানের প্রম্পট নির্মাণে মন দিন।"}
+              </p>
+            </div>
+
+            <div className="space-y-4 rounded-3xl border border-white/40 bg-white/10 p-6 backdrop-blur">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">
+                {isEnglish ? "Choose your path" : "আপনার পথ বেছে নিন"}
+              </p>
+              <div className="grid gap-3 text-sm font-semibold">
+                <a
+                  href="/community/submit"
+                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                >
+                  <span>{isEnglish ? "Creator onboarding" : "ক্রিয়েটর অনবোর্ডিং"}</span>
+                  <span aria-hidden>→</span>
+                </a>
+                <a
+                  href="#enterprise"
+                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                >
+                  <span>{isEnglish ? "Enterprise discovery" : "এন্টারপ্রাইজ ডিসকভারি"}</span>
+                  <span aria-hidden>→</span>
+                </a>
+                <a
+                  href="#insights"
+                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                >
+                  <span>{isEnglish ? "Download insights" : "ইনসাইটস ডাউনলোড"}</span>
+                  <span aria-hidden>→</span>
+                </a>
+              </div>
+
+              <div className="rounded-2xl border border-white/40 bg-white/20 p-4 text-sm text-white/80">
+                <p className="font-semibold uppercase tracking-[0.2em]">
+                  {isEnglish ? "72h Creator Care" : "৭২ ঘণ্টার ক্রিয়েটর কেয়ার"}
+                </p>
+                <p className="mt-1">
+                  {isEnglish
+                    ? "Dedicated bilingual concierge ensures every creator or enterprise request is resolved within three days."
+                    : "প্রতিটি ক্রিয়েটর বা এন্টারপ্রাইজ অনুরোধ ৩ দিনের মধ্যে সমাধান নিশ্চিত করতে ডেডিকেটেড কনসিয়ার্জ।"}
+                </p>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/70">
+                <span>Dhaka</span>
+                <span>•</span>
+                <span>Singapore</span>
+                <span>•</span>
+                <span>Dubai</span>
+                <span>•</span>
+                <span>New York</span>
+                <span>•</span>
+                <span>Lagos</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default FinalCTA;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,108 +1,136 @@
+import { useLanguage } from "@/contexts/LanguageContext";
 
-import { Facebook, Instagram, Twitter, Youtube } from "lucide-react";
+const footerLinks = [
+  {
+    headingEn: "Product",
+    headingBn: "প্রোডাক্ট",
+    links: [
+      { labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস", href: "#marketplace" },
+      { labelEn: "Creator Hub", labelBn: "ক্রিয়েটর হাব", href: "#creators" },
+      { labelEn: "Pricing", labelBn: "প্রাইসিং", href: "#pricing" },
+    ],
+  },
+  {
+    headingEn: "Solutions",
+    headingBn: "সমাধান",
+    links: [
+      { labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ", href: "#enterprise" },
+      { labelEn: "Compliance", labelBn: "কমপ্লায়েন্স", href: "#enterprise" },
+      { labelEn: "Insights", labelBn: "ইনসাইটস", href: "#insights" },
+    ],
+  },
+  {
+    headingEn: "Company",
+    headingBn: "কোম্পানি",
+    links: [
+      { labelEn: "Support", labelBn: "সাপোর্ট", href: "#support" },
+      { labelEn: "Community", labelBn: "কমিউনিটি", href: "/community/prompts" },
+      { labelEn: "Security", labelBn: "সিকিউরিটি", href: "#enterprise" },
+    ],
+  },
+];
+
+const complianceItems = [
+  { en: "GDPR Ready", bn: "GDPR প্রস্তুত" },
+  { en: "ISO 27001", bn: "ISO 27001" },
+  { en: "SOC 2", bn: "SOC 2" },
+  { en: "Bangladesh Data Protection", bn: "বাংলাদেশ ডেটা প্রোটেকশন" },
+];
 
 const Footer = () => {
   const currentYear = new Date().getFullYear();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
 
   return (
-    <footer className="bg-gray-900 text-gray-300">
-      <div className="container mx-auto px-4 md:px-6 py-12">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-          <div>
-            <div className="flex items-center gap-2 mb-4">
-              <div className="w-10 h-10 rounded-xl bg-gradient-to-r from-blue-500 to-violet-500 flex items-center justify-center text-white font-bold">
-                পি
+    <footer className="bg-[#0C1115] text-white">
+      <div className="mx-auto max-w-7xl px-4 py-16 md:px-8">
+        <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="space-y-6">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--gradient-aurora)] text-white">
+                <span className="text-lg font-semibold">BP</span>
               </div>
-              <span className="font-display font-bold text-xl text-white">
-                প্রম্পট শিক্ষা
-              </span>
+              <div>
+                <p className="text-base font-semibold">BanglaPrompt.ai</p>
+                <p className="text-xs uppercase tracking-[0.3em] text-white/70">
+                  {isEnglish
+                    ? "Bangladesh’s first prompt marketplace • Global reach"
+                    : "বাংলাদেশের প্রথম প্রম্পট মার্কেটপ্লেস • গ্লোবাল রিচ"}
+                </p>
+              </div>
             </div>
-            <p className="text-gray-400 mb-4">
-              বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শেখার সেরা প্ল্যাটফর্ম।
+            <p className="text-sm leading-relaxed text-white/70 md:text-base">
+              {isEnglish
+                ? "A global AI prompt marketplace connecting Bengali prompt creators with international buyers through bilingual storefronts, transparent revenue operations, and compliance-ready tooling."
+                : "দ্বিভাষিক স্টোরফ্রন্ট, স্বচ্ছ আয় ব্যবস্থাপনা ও কমপ্লায়েন্স-প্রস্তুত টুলিংয়ের মাধ্যমে বাংলা প্রম্পট নির্মাতাদেরকে আন্তর্জাতিক ক্রেতাদের সাথে যুক্ত করে BanglaPrompt.ai।"}
             </p>
-            <div className="flex space-x-4">
-              <a href="#" className="text-gray-400 hover:text-white transition-colors">
-                <Facebook className="w-5 h-5" />
-                <span className="sr-only">Facebook</span>
-              </a>
-              <a href="#" className="text-gray-400 hover:text-white transition-colors">
-                <Twitter className="w-5 h-5" />
-                <span className="sr-only">Twitter</span>
-              </a>
-              <a href="#" className="text-gray-400 hover:text-white transition-colors">
-                <Instagram className="w-5 h-5" />
-                <span className="sr-only">Instagram</span>
-              </a>
-              <a href="#" className="text-gray-400 hover:text-white transition-colors">
-                <Youtube className="w-5 h-5" />
-                <span className="sr-only">YouTube</span>
-              </a>
-            </div>
           </div>
-          
-          <div>
-            <h3 className="text-white font-semibold text-lg mb-4">কুইক লিংক</h3>
-            <ul className="space-y-2">
-              <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">হোম</a>
-              </li>
-              <li>
-                <a href="#features" className="text-gray-400 hover:text-white transition-colors">কোর্স</a>
-              </li>
-              <li>
-                <a href="#about" className="text-gray-400 hover:text-white transition-colors">আমাদের সম্পর্কে</a>
-              </li>
-              <li>
-                <a href="#contact" className="text-gray-400 hover:text-white transition-colors">যোগাযোগ</a>
-              </li>
-            </ul>
-          </div>
-          
-          <div>
-            <h3 className="text-white font-semibold text-lg mb-4">আমাদের কোর্স</h3>
-            <ul className="space-y-2">
-              <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">প্রম্পট ফান্ডামেন্টালস</a>
-              </li>
-              <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">উন্নত প্রম্পট কৌশল</a>
-              </li>
-              <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">সৃজনশীল লেখা</a>
-              </li>
-              <li>
-                <a href="#" className="text-gray-400 hover:text-white transition-colors">কোডিং এবং ডেভেলপমেন্ট</a>
-              </li>
-            </ul>
-          </div>
-          
-          <div>
-            <h3 className="text-white font-semibold text-lg mb-4">যোগাযোগ করুন</h3>
-            <ul className="space-y-2">
-              <li className="flex items-start">
-                <span className="text-gray-400 mr-2">ই:</span>
-                <a href="mailto:abir.abbas@proton.me" className="text-gray-400 hover:text-white transition-colors">abir.abbas@proton.me</a>
-              </li>
-              <li className="flex items-start">
-                <span className="text-gray-400 mr-2">ফো:</span>
-                <a href="tel:+8801841603542" className="text-gray-400 hover:text-white transition-colors">+880 1841 603 542</a>
-              </li>
-              <li className="flex items-start">
-                <span className="text-gray-400 mr-2">ঠি:</span>
-                <span className="text-gray-400">ঢাকা, বাংলাদেশ</span>
-              </li>
-            </ul>
+
+          <div className="grid gap-6 rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-white/80 backdrop-blur">
+            <p className="font-semibold uppercase tracking-[0.3em] text-white/60">
+              {isEnglish ? "Stay ahead" : "আপডেট থাকুন"}
+            </p>
+            <p className="text-sm text-white/80">
+              {isEnglish
+                ? "Subscribe for insights on the 2025 creator economy, localisation strategy, and responsible AI practices."
+                : "২০২৫ ক্রিয়েটর ইকোনমি, লোকালাইজেশন কৌশল ও রেসপনসিবল এআই সম্পর্কে ইনসাইটস পেতে সাবস্ক্রাইব করুন।"}
+            </p>
+            <form className="mt-4 flex flex-col gap-3 sm:flex-row">
+              <input
+                type="email"
+                required
+                placeholder={isEnglish ? "Work email" : "কর্মস্থলের ইমেইল"}
+                className="flex-1 rounded-full border border-white/20 bg-white/10 px-4 py-3 text-sm text-white placeholder:text-white/60 focus:border-white focus:outline-none"
+              />
+              <button
+                type="submit"
+                className="rounded-full bg-[var(--gradient-aurora)] px-6 py-3 text-sm font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+              >
+                {isEnglish ? "Subscribe" : "সাবস্ক্রাইব"}
+              </button>
+            </form>
           </div>
         </div>
-        
-        <div className="border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-gray-400 text-sm mb-4 md:mb-0">
-            &copy; {currentYear} প্রম্পট শিক্ষা। সর্বস্বত্ব সংরক্ষিত।
-          </p>
-          <div className="flex space-x-6">
-            <a href="#" className="text-gray-400 hover:text-white text-sm transition-colors">গোপনীয়তা নীতি</a>
-            <a href="#" className="text-gray-400 hover:text-white text-sm transition-colors">ব্যবহারের শর্তাবলী</a>
+
+        <div className="mt-16 grid gap-12 md:grid-cols-2 lg:grid-cols-4">
+          {footerLinks.map((group) => (
+            <div key={group.headingEn}>
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">
+                {isEnglish ? group.headingEn : group.headingBn}
+              </p>
+              <ul className="mt-4 space-y-3 text-sm text-white/70">
+                {group.links.map((link) => (
+                  <li key={link.labelEn}>
+                    <a href={link.href} className="transition-colors hover:text-white">
+                      {isEnglish ? link.labelEn : link.labelBn}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+
+          <div className="space-y-4">
+            <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">
+              {isEnglish ? "Compliance" : "কমপ্লায়েন্স"}
+            </p>
+            <ul className="space-y-2 text-sm text-white/70">
+              {complianceItems.map((item) => (
+                <li key={item.en}>{isEnglish ? item.en : item.bn}</li>
+              ))}
+            </ul>
+            <p className="text-xs text-white/60">
+              {isEnglish
+                ? "Data residency: Singapore • Frankfurt • Mumbai • Dhaka"
+                : "ডাটা রেসিডেন্সি: সিঙ্গাপুর • ফ্রাঙ্কফুর্ট • মুম্বাই • ঢাকা"}
+            </p>
           </div>
+        </div>
+
+        <div className="mt-16 flex flex-col gap-4 border-t border-white/10 pt-6 text-xs text-white/60 md:flex-row md:items-center md:justify-between">
+          <p>© {currentYear} BanglaPrompt.ai. {isEnglish ? "All rights reserved." : "সমস্ত স্বত্ব সংরক্ষিত।"}</p>
+          <p>{isEnglish ? "Built with Bengali creativity for global teams." : "বাংলা সৃজনশীলতায় নির্মিত—গ্লোবাল টিমের জন্য।"}</p>
         </div>
       </div>
     </footer>

--- a/src/components/GlobalCommunity.tsx
+++ b/src/components/GlobalCommunity.tsx
@@ -1,0 +1,129 @@
+import { Globe2, Users } from "lucide-react";
+
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const regions = [
+  {
+    regionEn: "South Asia",
+    regionBn: "দক্ষিণ এশিয়া",
+    highlightEn: "Bangladesh, India, Pakistan",
+    highlightBn: "বাংলাদেশ, ভারত, পাকিস্তান",
+    adoptionEn: "37% of creator base",
+    adoptionBn: "ক্রিয়েটর বেসের ৩৭%",
+  },
+  {
+    regionEn: "Middle East",
+    regionBn: "মধ্যপ্রাচ্য",
+    highlightEn: "Saudi Arabia, UAE, Qatar",
+    highlightBn: "সৌদি আরব, ইউএই, কাতার",
+    adoptionEn: "Enterprise telco & retail",
+    adoptionBn: "এন্টারপ্রাইজ টেলকো ও রিটেল",
+  },
+  {
+    regionEn: "North America",
+    regionBn: "উত্তর আমেরিকা",
+    highlightEn: "USA, Canada",
+    highlightBn: "যুক্তরাষ্ট্র, কানাডা",
+    adoptionEn: "Diaspora media & fintech",
+    adoptionBn: "প্রবাসী মিডিয়া ও ফিনটেক",
+  },
+  {
+    regionEn: "Europe & UK",
+    regionBn: "ইউরোপ ও যুক্তরাজ্য",
+    highlightEn: "UK, Germany, Netherlands",
+    highlightBn: "যুক্তরাজ্য, জার্মানি, নেদারল্যান্ডস",
+    adoptionEn: "Cultural institutions",
+    adoptionBn: "সাংস্কৃতিক প্রতিষ্ঠান",
+  },
+];
+
+const GlobalCommunity = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <section className="section">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="space-y-8">
+            <p className="section-eyebrow">{isEnglish ? "Global Community" : "গ্লোবাল কমিউনিটি"}</p>
+            <h2 className="section-heading">
+              {isEnglish
+                ? "Bengali ingenuity powering 70+ countries."
+                : "৭০+ দেশে এআই টিমকে শক্তি জোগাচ্ছে বাঙালি উদ্ভাবন।"}
+            </h2>
+            <p className="section-subheading">
+              {isEnglish
+                ? "A global constellation of creators, enterprises, and partners shaping culturally aware AI—bridging Dhaka’s imagination with New York boardrooms and Lagos innovation hubs."
+                : "একটি বৈশ্বিক নক্ষত্রপুঞ্জ যেখানে নির্মাতা, এন্টারপ্রাইজ ও পার্টনাররা একসাথে সাংস্কৃতিকভাবে সচেতন এআই গড়ছে—ঢাকার কল্পনাকে নিউ ইয়র্কের বোর্ডরুম ও লাগোসের উদ্ভাবনী কেন্দ্রের সাথে যুক্ত করছে।"}
+            </p>
+
+            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex items-center gap-3">
+                <Globe2 className="h-6 w-6 text-primary" />
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isEnglish ? "70+ countries" : "৭০+ দেশ"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {isEnglish ? "Bengali-first prompt exchanges" : "বাংলা-প্রথম প্রম্পট এক্সচেঞ্জ"}
+                  </p>
+                </div>
+              </div>
+              <div className="mt-4 grid gap-4 text-sm text-muted-foreground md:grid-cols-2">
+                <div className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <p className="text-foreground font-semibold">
+                    {isEnglish ? "300+ enterprise teams" : "৩০০+ এন্টারপ্রাইজ টিম"}
+                  </p>
+                  <p>{isEnglish ? "Fortune 500, telco, fintech" : "ফরচুন ৫০০, টেলকো, ফিনটেক"}</p>
+                </div>
+                <div className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <p className="text-foreground font-semibold">
+                    {isEnglish ? "42,000+ prompts" : "৪২,০০০+ প্রম্পট"}
+                  </p>
+                  <p>{isEnglish ? "Localized to industry & tone" : "ইন্ডাস্ট্রি ও টোন অনুযায়ী লোকালাইজড"}</p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+            <div className="flex items-center justify-between">
+              <h3 className="text-base font-semibold text-foreground">
+                {isEnglish ? "Regional adoption heatmap" : "রিজিওনাল অ্যাডপশন হিটম্যাপ"}
+              </h3>
+              <Users className="h-5 w-5 text-primary" />
+            </div>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {isEnglish
+                ? "Explore how BanglaPrompt.ai is embedded across creative, operational, and compliance teams."
+                : "ক্রিয়েটিভ, অপারেশনাল ও কমপ্লায়েন্স টিমে BanglaPrompt.ai কীভাবে প্রয়োগ হচ্ছে তা জানুন।"}
+            </p>
+
+            <div className="mt-6 grid gap-4">
+              {regions.map((region) => (
+                <div key={region.regionEn} className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">
+                        {isEnglish ? region.regionEn : region.regionBn}
+                      </p>
+                      <p className="text-xs text-muted-foreground">
+                        {isEnglish ? region.highlightEn : region.highlightBn}
+                      </p>
+                    </div>
+                    <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                      {isEnglish ? region.adoptionEn : region.adoptionBn}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default GlobalCommunity;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,106 +1,153 @@
+import { useLanguage } from "@/contexts/LanguageContext";
 
-import { ArrowRight } from "lucide-react";
-import GlassCard from "./ui-custom/GlassCard";
+const marketplaceStats = [
+  { value: "42K+", en: "curated prompts", bn: "কিউরেটেড প্রম্পট" },
+  { value: "70+", en: "countries activated", bn: "দেশে ব্যবহৃত" },
+  { value: "72h", en: "creator payouts", bn: "ক্রিয়েটর পেআউট" },
+  { value: "300+", en: "enterprise teams", bn: "এন্টারপ্রাইজ টিম" },
+];
 
 const Hero = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
   return (
-    <section className="relative pt-32 pb-20 md:pt-40 md:pb-32 overflow-hidden bangladesh-pattern">
-      {/* Background pattern */}
-      <div className="absolute inset-0 bg-primary/5 -z-10" />
-      
-      {/* Traditional decorative elements */}
-      <div className="absolute top-20 left-10 w-32 h-32 rounded-full bg-primary/10 blur-xl animate-pulse"></div>
-      <div className="absolute bottom-20 right-10 w-40 h-40 rounded-full bg-accent/10 blur-xl animate-pulse" style={{animationDelay: '1s'}}></div>
-      
-      <div className="container mx-auto px-4 md:px-6">
-        <div className="flex flex-col items-center text-center max-w-5xl mx-auto">
-          {/* Cultural badge */}
-          <div className="inline-flex items-center gap-2 px-4 py-2 bg-primary/10 text-primary rounded-full mb-8 border border-primary/20">
-            <span className="text-2xl">🇧🇩</span>
-            <span className="font-bengali font-medium">বাংলাদেশের প্রথম AI শিক্ষা প্ল্যাটফর্ম</span>
-          </div>
-          
-          <h1 className="text-5xl md:text-7xl font-bold font-display mb-6 bg-gradient-to-r from-primary via-accent to-secondary text-transparent bg-clip-text">
-            প্রম্পট শিক্ষা
-          </h1>
-          <p className="text-xl md:text-2xl font-bengali text-gray-700 mb-4 leading-relaxed">
-            বাংলায় AI এর শক্তি আনলক করুন
-          </p>
-          <p className="text-lg font-bengali text-gray-600 mb-8 max-w-2xl mx-auto leading-relaxed">
-            দেশের সবচেয়ে বড় প্রম্পট ইঞ্জিনিয়ারিং কমিউনিটিতে যোগ দিন। 
-            বিশেষজ্ঞদের থেকে শিখুন, নিজের দক্ষতা বাড়ান এবং AI যুগে এগিয়ে থাকুন।
-          </p>
-          
-          <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-            <a href="#features" className="inline-flex items-center gap-2 bg-gradient-to-r from-primary to-primary/80 hover:from-primary/90 hover:to-primary/70 text-white px-8 py-4 text-lg font-bengali rounded-lg shadow-cultural transition-all duration-200 hover:scale-105">
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-              </svg>
-              শেখা শুরু করুন
-            </a>
-            <a href="#contact" className="inline-flex items-center gap-2 border-2 border-primary text-primary hover:bg-primary/5 px-8 py-4 text-lg font-bengali rounded-lg transition-all duration-200">
-              <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h1.5a2.5 2.5 0 015 0H17m-5 8l-3-3h6l-3 3z" />
-              </svg>
-              ডেমো দেখুন
-            </a>
-          </div>
-          
-          {/* Cultural statistics */}
-          <div className="mt-16 grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
-            <div className="cultural-card p-4 rounded-lg">
-              <div className="text-2xl font-bold text-primary font-display">১০,০০০+</div>
-              <div className="text-sm font-bengali text-gray-600">শিক্ষার্থী</div>
+    <section id="top" className="relative overflow-hidden pt-32 pb-24 md:pt-40 md:pb-32">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -left-32 top-10 h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
+        <div className="absolute right-0 top-0 h-full w-[55%] bg-[var(--gradient-midnight)] opacity-[0.92]" />
+        <div className="absolute -right-32 bottom-[-10rem] h-96 w-96 rounded-full bg-secondary/20 blur-3xl" />
+        <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-background to-transparent" />
+      </div>
+
+      <div className="relative mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid items-center gap-16 lg:grid-cols-[1.05fr_0.95fr]">
+          <div className="space-y-10">
+            <div className="inline-flex flex-wrap items-center gap-3 rounded-full border border-white/40 bg-white/75 px-4 py-2 text-xs font-semibold tracking-[0.18em] uppercase text-muted-foreground shadow-sm backdrop-blur">
+              <span className="text-foreground">
+                {isEnglish
+                  ? "🇧🇩 Bangladesh’s First AI Prompt Marketplace"
+                  : "🇧🇩 বাংলাদেশের প্রথম এআই প্রম্পট মার্কেটপ্লেস"}
+              </span>
             </div>
-            <div className="cultural-card p-4 rounded-lg">
-              <div className="text-2xl font-bold text-accent font-display">৯৮%</div>
-              <div className="text-sm font-bengali text-gray-600">সফলতার হার</div>
-            </div>
-            <div className="cultural-card p-4 rounded-lg">
-              <div className="text-2xl font-bold text-secondary font-display">৫০+</div>
-              <div className="text-sm font-bengali text-gray-600">কোর্স মডিউল</div>
-            </div>
-            <div className="cultural-card p-4 rounded-lg">
-              <div className="text-2xl font-bold text-primary font-display">২৪/৭</div>
-              <div className="text-sm font-bengali text-gray-600">সাপোর্ট</div>
-            </div>
-          </div>
-        </div>
-        
-        <div className="mt-16 md:mt-24 grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 max-w-5xl mx-auto">
-          <div className="cartoon-card animate-fade-in" style={{ animationDelay: "0.4s" }}>
-            <div className="flex flex-col items-center text-center">
-              <div className="w-16 h-16 rounded-full bg-orange-500 flex items-center justify-center mb-4 border-4 border-black">
-                <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
-                </svg>
+
+            <div className="space-y-6">
+              <h1 className="text-4xl font-semibold leading-tight text-foreground md:text-5xl lg:text-6xl">
+                {isEnglish ? (
+                  <>
+                    <span className="block">Bangladesh’s first AI prompt marketplace.</span>
+                    <span className="block bg-clip-text text-transparent" style={{ backgroundImage: "var(--gradient-aurora)" }}>
+                      Sell Bengali brilliance to global teams.
+                    </span>
+                  </>
+                ) : (
+                  <>
+                    <span className="block">বাংলাদেশের প্রথম এআই প্রম্পট মার্কেটপ্লেস।</span>
+                    <span className="block bg-clip-text text-transparent" style={{ backgroundImage: "var(--gradient-aurora)" }}>
+                      বাংলা সৃজনশীলতা এখন বিশ্বব্যাপী টিমের হাতে।
+                    </span>
+                  </>
+                )}
+              </h1>
+
+              <div className="grid gap-6 text-base md:text-lg">
+                <p className="bilingual-copy max-w-2xl text-foreground">
+                  {isEnglish
+                    ? "Launch your prompt storefront, package workflows for GPT-4.1, Claude 3, and Gemini Ultra, and reach verified buyers with transparent revenue tools."
+                    : "আপনার প্রম্পট স্টোরফ্রন্ট চালু করুন, GPT-4.1, Claude 3 ও Gemini Ultra’র জন্য ওয়ার্কফ্লো প্রস্তুত করুন এবং স্বচ্ছ আয়ের ড্যাশবোর্ড নিয়ে যাচাইকৃত ক্রেতাদের কাছে পৌঁছান।"}
+                </p>
               </div>
-              <h3 className="cartoon-subtitle mb-2">বাংলায় শিক্ষা</h3>
-              <p className="font-bengali text-black/70 text-lg">নিজের মাতৃভাষায় সহজবোধ্য প্রম্পট ইঞ্জিনিয়ারিং শিখুন</p>
+
+              <ul className="grid gap-4 text-sm md:grid-cols-2 md:text-base">
+                <li className="rounded-2xl border border-white/60 bg-white/70 px-5 py-4 shadow-sm backdrop-blur">
+                  <span className="block font-semibold text-foreground">
+                    {isEnglish ? "Creator storefront toolkit" : "ক্রিয়েটর স্টোরফ্রন্ট টুলকিট"}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {isEnglish
+                      ? "Upload prompt bundles, manage licensing, and share preview outputs in minutes."
+                      : "মিনিটেই প্রম্পট বান্ডেল আপলোড, লাইসেন্স নির্ধারণ ও প্রিভিউ আউটপুট শেয়ার করুন।"}
+                  </span>
+                </li>
+                <li className="rounded-2xl border border-white/60 bg-white/70 px-5 py-4 shadow-sm backdrop-blur">
+                  <span className="block font-semibold text-foreground">
+                    {isEnglish ? "Enterprise buying confidence" : "এন্টারপ্রাইজ ক্রয়ের আত্মবিশ্বাস"}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {isEnglish
+                      ? "Contracts, compliance, and analytics that help procurement teams activate your prompts fast."
+                      : "চুক্তি, কমপ্লায়েন্স ও অ্যানালিটিক্স দিয়ে প্রোকিউরমেন্ট টিম দ্রুত আপনার প্রম্পট চালু করতে পারে।"}
+                  </span>
+                </li>
+              </ul>
+            </div>
+
+            <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+              <a
+                href="#marketplace"
+                className="rounded-full bg-[var(--gradient-aurora)] px-8 py-3 text-base font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+              >
+                <span className="block">{isEnglish ? "Browse Marketplace" : "মার্কেটপ্লেস দেখুন"}</span>
+              </a>
+              <a
+                href="#creators"
+                className="rounded-full border border-white/70 bg-white/70 px-8 py-3 text-base font-semibold text-foreground shadow-sm backdrop-blur transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-soft)]"
+              >
+                <span className="block">{isEnglish ? "Start Selling Prompts" : "প্রম্পট বিক্রি শুরু করুন"}</span>
+              </a>
             </div>
           </div>
-          
-          <div className="cartoon-card animate-fade-in" style={{ animationDelay: "0.5s" }}>
-            <div className="flex flex-col items-center text-center">
-              <div className="w-16 h-16 rounded-full bg-purple-500 flex items-center justify-center mb-4 border-4 border-black">
-                <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />
-                </svg>
+
+          <div className="relative">
+            <div className="gradient-border glass-panel relative overflow-hidden rounded-[2rem] p-8 text-white">
+              <div className="absolute -right-12 -top-12 h-48 w-48 rounded-full bg-secondary/40 blur-3xl" />
+              <div className="absolute -bottom-16 left-12 h-56 w-56 rounded-full bg-primary/40 blur-3xl" />
+
+              <div className="relative space-y-8">
+                <div>
+                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-white/80">
+                    {isEnglish ? "Marketplace snapshot" : "মার্কেটপ্লেস স্ন্যাপশট"}
+                  </span>
+                  <h2 className="mt-3 text-3xl font-semibold leading-tight">
+                    {isEnglish ? "Built for prompt commerce in 2025." : "২০২৫ সালের প্রম্পট কমার্সের জন্য কিউরেটেড মার্কেটপ্লেস।"}
+                  </h2>
+                </div>
+
+                <div className="grid gap-6 sm:grid-cols-2">
+                  {marketplaceStats.map((stat) => (
+                    <div key={stat.value} className="rounded-2xl border border-white/30 bg-white/10 px-4 py-5 shadow-sm backdrop-blur">
+                      <div className="text-3xl font-semibold">{stat.value}</div>
+                      <div className="text-sm uppercase tracking-[0.2em] text-white/70">
+                        {isEnglish ? stat.en : stat.bn}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="rounded-2xl border border-white/25 bg-white/10 px-6 py-5 shadow-sm backdrop-blur">
+                  <div className="flex flex-wrap items-center justify-between gap-4 text-sm">
+                    <div>
+                      <span className="font-semibold uppercase tracking-[0.25em] text-secondary">
+                        {isEnglish ? "Priority buyer hubs" : "প্রাথমিক ক্রেতা কেন্দ্র"}
+                      </span>
+                      <p className="mt-1 text-white/80">Dhaka • Singapore • Dubai • New York • Lagos</p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs uppercase tracking-[0.3em] text-white/60">
+                        {isEnglish ? "Marketplace flywheel" : "মার্কেটপ্লেস ফ্লাইহুইল"}
+                      </p>
+                      <p className="text-sm text-white/80">
+                        {isEnglish ? "Discovery → Licensing → Revenue care" : "ডিসকভারি → লাইসেন্সিং → রেভিনিউ কেয়ার"}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="mt-3 text-sm text-white/70">
+                    {isEnglish
+                      ? "Culturally rich catalogs, licensing, and global support combine to create a commerce-ready marketplace."
+                      : "সংস্কৃতিময় প্রম্পট ক্যাটালগ, লাইসেন্সিং ও গ্লোবাল সমর্থনের সমন্বয়ে বানিজ্যিকভাবে প্রস্তুত মার্কেটপ্লেস।"}
+                  </p>
+                </div>
               </div>
-              <h3 className="cartoon-subtitle mb-2">হাতে-কলমে প্রশিক্ষণ</h3>
-              <p className="font-bengali text-black/70 text-lg">ব্যবহারিক প্রকল্পের মাধ্যমে আত্মবিশ্বাসী হয়ে উঠুন</p>
-            </div>
-          </div>
-          
-          <div className="cartoon-card animate-fade-in" style={{ animationDelay: "0.6s" }}>
-            <div className="flex flex-col items-center text-center">
-              <div className="w-16 h-16 rounded-full bg-blue-500 flex items-center justify-center mb-4 border-4 border-black">
-                <svg className="w-8 h-8 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M13 10V3L4 14h7v7l9-11h-7z" />
-                </svg>
-              </div>
-              <h3 className="cartoon-subtitle mb-2">দক্ষতা উন্নয়ন</h3>
-              <p className="font-bengali text-black/70 text-lg">আধুনিক এআই টুল ব্যবহারে দক্ষতা অর্জন করুন</p>
             </div>
           </div>
         </div>

--- a/src/components/InsightsHub.tsx
+++ b/src/components/InsightsHub.tsx
@@ -1,0 +1,87 @@
+import { FileText, Library, NotebookPen } from "lucide-react";
+
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const resources = [
+  {
+    titleEn: "2025 Generative AI Localization Report",
+    titleBn: "২০২৫ জেনারেটিভ এআই লোকালাইজেশন রিপোর্ট",
+    summaryEn:
+      "Benchmarking AI prompt adoption across South Asia, MENA, and diaspora regions with case studies from telecom, retail, and finance.",
+    summaryBn:
+      "দক্ষিণ এশিয়া, মেনা ও প্রবাসী বাজারে এআই প্রম্পট ব্যবহারের বেঞ্চমার্ক—টেলিকম, রিটেল ও ফাইন্যান্স কেস স্টাডি সহ।",
+    link: "#",
+    icon: FileText,
+  },
+  {
+    titleEn: "Creator Economy Benchmarks",
+    titleBn: "ক্রিয়েটর ইকোনমি বেঞ্চমার্ক",
+    summaryEn:
+      "Revenue, retention, and collaboration metrics for Bengali-first creators operating on global stages.",
+    summaryBn:
+      "গ্লোবাল প্ল্যাটফর্মে কাজ করা বাংলা নির্মাতাদের রেভিনিউ, রিটেনশন ও সহযোগিতার মেট্রিকস।",
+    link: "#",
+    icon: Library,
+  },
+  {
+    titleEn: "Responsible AI Handbook",
+    titleBn: "রেসপনসিবল এআই হ্যান্ডবুক",
+    summaryEn:
+      "Policy templates, ethical guidelines, and consent frameworks co-authored with Bangladeshi legal partners.",
+    summaryBn:
+      "বাংলাদেশি লিগ্যাল পার্টনারদের সাথে তৈরি নীতিমালা টেমপ্লেট, নৈতিক নির্দেশিকা ও সম্মতি কাঠামো।",
+    link: "#",
+    icon: NotebookPen,
+  },
+];
+
+const InsightsHub = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <section id="insights" className="section bg-gradient-to-b from-background to-primary/10">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="section-eyebrow">{isEnglish ? "Insights & Research" : "ইনসাইটস ও রিসার্চ"}</p>
+          <h2 className="section-heading">
+            {isEnglish
+              ? "Intelligence hub for the Bengali prompt economy."
+              : "বাংলা প্রম্পট অর্থনীতির ইন্টেলিজেন্স হাব।"}
+          </h2>
+          <p className="section-subheading mx-auto mt-6">
+            {isEnglish
+              ? "Strategic research grounded in product rigour and cultural intelligence—built to help teams scale prompt commerce responsibly."
+              : "পণ্যের নিখুঁততা ও সাংস্কৃতিক বুদ্ধিমত্তার মেলবন্ধনে তৈরি কৌশলগত রিসার্চ—যা টিমগুলোকে দায়িত্বশীলভাবে প্রম্পট কমার্স স্কেল করতে সহায়তা করে।"}
+          </p>
+        </div>
+
+        <div className="mt-12 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          {resources.map((resource) => (
+            <a
+              key={resource.titleEn}
+              href={resource.link}
+              className="group rounded-[2rem] border border-white/60 bg-white/80 p-6 text-left shadow-[var(--shadow-soft)] transition-all hover:-translate-y-1 hover:shadow-[var(--shadow-elevated)]"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+                <resource.icon className="h-5 w-5" />
+              </div>
+              <h3 className="mt-4 text-lg font-semibold text-foreground">
+                {isEnglish ? resource.titleEn : resource.titleBn}
+              </h3>
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                {isEnglish ? resource.summaryEn : resource.summaryBn}
+              </p>
+              <span className="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary">
+                {isEnglish ? "Download briefing" : "ব্রিফিং ডাউনলোড"}
+                <span aria-hidden>→</span>
+              </span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default InsightsHub;

--- a/src/components/MediumSubscriptionPopup.tsx
+++ b/src/components/MediumSubscriptionPopup.tsx
@@ -2,34 +2,42 @@ import { useState, useEffect } from 'react';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { ExternalLink, X, Users, Star, TrendingUp } from 'lucide-react';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 const MediumSubscriptionPopup = () => {
+  const { language } = useLanguage();
+  const isBn = language === 'bn';
+
   const [isOpen, setIsOpen] = useState(false);
-  const [timeLeft, setTimeLeft] = useState(300); // 5 minutes countdown
+  const [timeLeft, setTimeLeft] = useState(300);
 
   useEffect(() => {
-    // Show popup after 8 seconds for better timing
+    if (!isBn) {
+      setIsOpen(false);
+      return;
+    }
+
     const timer = setTimeout(() => {
       const hasSeenPopup = localStorage.getItem('mediumPopupSeen');
       const lastShown = localStorage.getItem('mediumPopupLastShown');
       const now = Date.now();
-      
-      // Show if never seen or if it's been more than 24 hours
+
       if (!hasSeenPopup || (lastShown && now - parseInt(lastShown) > 24 * 60 * 60 * 1000)) {
         setIsOpen(true);
       }
     }, 8000);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [isBn]);
 
   useEffect(() => {
-    let countdown: NodeJS.Timeout;
-    if (isOpen && timeLeft > 0) {
-      countdown = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
+    if (!isBn || !isOpen || timeLeft <= 0) {
+      return;
     }
+
+    const countdown = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
     return () => clearTimeout(countdown);
-  }, [isOpen, timeLeft]);
+  }, [isBn, isOpen, timeLeft]);
 
   const handleSubscribe = () => {
     localStorage.setItem('mediumPopupSeen', 'true');
@@ -49,6 +57,10 @@ const MediumSubscriptionPopup = () => {
     const secs = seconds % 60;
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
+
+  if (!isBn) {
+    return null;
+  }
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>

--- a/src/components/MonetizationAds.tsx
+++ b/src/components/MonetizationAds.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import GoogleAd from './GoogleAd';
 
 interface MonetizationAdsProps {
-  placement: 'header' | 'sidebar' | 'content' | 'footer' | 'mobile';
+  placement: 'header' | 'sidebar' | 'content' | 'footer' | 'mobile' | 'inline';
   className?: string;
 }
 
@@ -27,6 +27,12 @@ const MonetizationAds: React.FC<MonetizationAdsProps> = ({ placement, className 
           slot: '3456789012',
           format: 'rectangle' as const,
           className: 'my-8'
+        };
+      case 'inline':
+        return {
+          slot: '6789012345',
+          format: 'auto' as const,
+          className: 'my-4'
         };
       case 'footer':
         return {

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,112 +1,174 @@
-
-import { useState, useEffect } from "react";
-import { Menu, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Globe2, Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const navLinks = [
+  { href: "#marketplace", labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস" },
+  { href: "#creators", labelEn: "For Creators", labelBn: "ক্রিয়েটরদের জন্য" },
+  { href: "#enterprise", labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ" },
+  { href: "#pricing", labelEn: "Pricing", labelBn: "প্রাইসিং" },
+  { href: "#insights", labelEn: "Insights", labelBn: "ইনসাইটস" },
+  { href: "#support", labelEn: "Support", labelBn: "সাপোর্ট" },
+];
 
 const Navbar = () => {
   const [scrolled, setScrolled] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const { language, setLanguage } = useLanguage();
+  const isEnglish = language === "en";
 
   useEffect(() => {
     const handleScroll = () => {
-      const isScrolled = window.scrollY > 10;
-      if (isScrolled !== scrolled) {
-        setScrolled(isScrolled);
-      }
+      setScrolled(window.scrollY > 10);
     };
 
     window.addEventListener("scroll", handleScroll);
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-    };
-  }, [scrolled]);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
-  const navLinks = [
-    { name: "হোম", href: "#" },
-    { name: "কোর্স", href: "#features" },
-    { name: "রিসোর্স", href: "#resources" },
-    { name: "কমিউনিটি", href: "/community/prompts" },
-    { name: "সম্পর্কে", href: "#about" },
-  ];
+  const renderNavLinks = (className?: string) =>
+    navLinks.map((link) => (
+      <a
+        key={link.href}
+        href={link.href}
+        className={cn(
+          "flex flex-col items-center text-xs font-medium text-muted-foreground/80 transition-colors hover:text-foreground md:text-[0.85rem]",
+          className,
+        )}
+        onClick={() => setMenuOpen(false)}
+      >
+        <span>{isEnglish ? link.labelEn : link.labelBn}</span>
+      </a>
+    ));
 
   return (
     <header
       className={cn(
-        "fixed top-0 left-0 right-0 z-50 transition-all duration-300 py-4",
-        scrolled ? "bg-white/80 backdrop-blur-md shadow-sm" : "bg-transparent"
+        "fixed top-0 left-0 right-0 z-50 transition-all duration-500",
+        scrolled
+          ? "bg-white/80 backdrop-blur-xl shadow-[0_20px_60px_-24px_rgba(12,17,21,0.45)]"
+          : "bg-transparent",
       )}
     >
-      <div className="container mx-auto px-4 md:px-6">
-        <div className="flex items-center justify-between">
-          <a href="#" className="flex items-center gap-2">
-            <div className="w-10 h-10 rounded-xl bg-gradient-to-r from-blue-500 to-violet-500 flex items-center justify-center text-white font-bold">
-              পি
-            </div>
-            <span className="font-display font-bold text-xl hidden sm:block">
-              প্রম্পট শিক্ষা
+      <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 md:px-8">
+        <a href="#top" className="flex items-center gap-3">
+          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--gradient-aurora)] text-white shadow-[var(--shadow-soft)]">
+            <span className="text-lg font-semibold">BP</span>
+          </div>
+          <div className="hidden text-left md:block">
+            <span className="text-sm font-semibold text-foreground md:text-base">BanglaPrompt.ai</span>
+            <span className="block text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground/80">
+              Global Prompt Marketplace
             </span>
-          </a>
+          </div>
+        </a>
 
-          {/* Desktop Navigation */}
-          <nav className="hidden md:flex items-center gap-6">
-            {navLinks.map((link) => (
-              <a
-                key={link.name}
-                href={link.href}
-                className="font-medium text-sm text-gray-700 hover:text-blue-600 transition-colors"
-              >
-                {link.name}
-              </a>
-            ))}
-          </nav>
+        <nav className="hidden items-center gap-6 lg:flex">{renderNavLinks()}</nav>
 
-          <div className="hidden md:flex items-center gap-4">
-            <a
-              href="/community/submit"
-              className="px-5 py-2 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white font-medium transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 active:scale-[0.98]"
+        <div className="hidden items-center gap-3 lg:flex">
+          <div className="flex items-center gap-1 rounded-full border border-white/70 bg-white/40 px-3 py-1.5 text-xs shadow-sm backdrop-blur">
+            <Globe2 className="h-4 w-4 text-primary" />
+            <button
+              type="button"
+              onClick={() => setLanguage("en")}
+              className={cn(
+                "rounded-full px-2 py-1 font-medium transition-colors",
+                isEnglish ? "bg-primary text-white" : "text-muted-foreground",
+              )}
             >
-              কমিউনিটিতে যোগ দিন
-            </a>
+              EN
+            </button>
+            <span className="text-muted-foreground/60">|</span>
+            <button
+              type="button"
+              onClick={() => setLanguage("bn")}
+              className={cn(
+                "rounded-full px-2 py-1 font-medium transition-colors",
+                !isEnglish ? "bg-primary text-white" : "text-muted-foreground",
+              )}
+            >
+              বাংলা
+            </button>
           </div>
 
-          {/* Mobile Navigation */}
-          <button
-            className="md:hidden"
-            onClick={() => setMenuOpen(!menuOpen)}
-            aria-label="Toggle Menu"
+          <a
+            href="/community/prompts"
+            className="text-right text-sm font-semibold text-muted-foreground transition-colors hover:text-foreground"
           >
-            {menuOpen ? (
-              <X className="w-6 h-6 text-gray-700" />
-            ) : (
-              <Menu className="w-6 h-6 text-gray-700" />
-            )}
-          </button>
+            <span>{isEnglish ? "Sign In" : "সাইন ইন"}</span>
+          </a>
+
+          <a
+            href="#cta"
+            className="rounded-full bg-[var(--gradient-aurora)] px-5 py-2 text-sm font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+          >
+            <span>{isEnglish ? "Get Started" : "আজই শুরু করুন"}</span>
+          </a>
         </div>
+
+        <button
+          type="button"
+          className="flex h-11 w-11 items-center justify-center rounded-xl border border-white/80 bg-white/60 text-foreground shadow-sm backdrop-blur lg:hidden"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label="Toggle navigation menu"
+        >
+          {menuOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
       </div>
 
-      {/* Mobile Menu */}
       {menuOpen && (
-        <div className="md:hidden absolute top-full left-0 right-0 bg-white/95 backdrop-blur-md shadow-lg animate-fade-in">
-          <div className="container mx-auto px-4 py-4">
-            <nav className="flex flex-col gap-4">
-              {navLinks.map((link) => (
-                <a
-                  key={link.name}
-                  href={link.href}
-                  className="font-medium text-gray-700 hover:text-blue-600 transition-colors py-2"
-                  onClick={() => setMenuOpen(false)}
+        <div className="lg:hidden">
+          <div className="mx-4 mb-4 space-y-6 rounded-2xl border border-white/80 bg-white/90 p-6 shadow-[var(--shadow-soft)] backdrop-blur-lg">
+            <div className="flex items-center justify-between rounded-2xl bg-muted/40 px-4 py-3">
+              <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                <Globe2 className="h-4 w-4 text-primary" />
+                <span>Language</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => setLanguage("en")}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-semibold",
+                    isEnglish
+                      ? "bg-primary text-white shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
                 >
-                  {link.name}
-                </a>
-              ))}
+                  EN
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setLanguage("bn")}
+                  className={cn(
+                    "rounded-full px-3 py-1 text-xs font-semibold",
+                    !isEnglish
+                      ? "bg-primary text-white shadow-sm"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  বাংলা
+                </button>
+              </div>
+            </div>
+
+            <nav className="grid gap-4 text-center">{renderNavLinks("py-1")}</nav>
+
+            <div className="grid gap-3">
               <a
-                href="/community/submit"
-                className="px-5 py-2 rounded-full bg-gradient-to-r from-blue-500 to-violet-500 text-white font-medium text-center transition-all duration-300 hover:shadow-lg hover:shadow-blue-500/20 active:scale-[0.98]"
-                onClick={() => setMenuOpen(false)}
+                href="/community/prompts"
+                className="rounded-xl border border-muted-foreground/20 px-4 py-3 text-sm font-semibold text-foreground shadow-sm"
               >
-                কমিউনিটিতে যোগ দিন
+                <span className="block">{isEnglish ? "Sign In" : "সাইন ইন"}</span>
               </a>
-            </nav>
+              <a
+                href="#cta"
+                className="rounded-xl bg-[var(--gradient-aurora)] px-4 py-3 text-sm font-semibold text-white shadow-[var(--shadow-soft)]"
+              >
+                <span className="block">{isEnglish ? "Get Started" : "আজই শুরু করুন"}</span>
+              </a>
+            </div>
           </div>
         </div>
       )}

--- a/src/components/OptimizedAdLayout.tsx
+++ b/src/components/OptimizedAdLayout.tsx
@@ -1,51 +1,48 @@
-import React from 'react';
-import AdsterraAds from './AdsterraAds';
-import MonetizationAds from './MonetizationAds';
+import React from "react";
+import MonetizationAds from "./MonetizationAds";
 
 interface OptimizedAdLayoutProps {
   children: React.ReactNode;
 }
 
 const OptimizedAdLayout: React.FC<OptimizedAdLayoutProps> = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+
+  const contentWithInlineAd = childArray.flatMap((child, index) => {
+    const segments = [child];
+
+    if (index === 2) {
+      segments.push(
+        <div
+          key={`inline-ad-${index}`}
+          className="flex w-full justify-center px-4"
+          aria-label="sponsored highlight"
+        >
+          <div className="inline-flex w-full max-w-xs flex-col items-center gap-2 rounded-2xl border border-border/40 bg-white/80 p-4 text-center shadow-[var(--shadow-soft)] backdrop-blur">
+            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground/70">
+              Sponsored
+            </span>
+            <MonetizationAds placement="inline" className="mt-0 w-full" />
+          </div>
+        </div>
+      );
+    }
+
+    return segments;
+  });
+
   return (
-    <div className="min-h-screen relative">
-      {/* Main Content with Sidebar Ads */}
-      <div className="container mx-auto px-4 py-8">
-        <div className="grid grid-cols-1 lg:grid-cols-4 gap-8">
-          {/* Sidebar */}
-          <div className="lg:col-span-1 order-2 lg:order-1">
-            <div className="sticky top-4">
-              <MonetizationAds placement="sidebar" />
-            </div>
-          </div>
+    <div className="relative flex min-h-screen flex-col bg-gradient-to-b from-white via-white to-muted/20">
+      <div className="flex-1 space-y-0">{contentWithInlineAd}</div>
 
-          {/* Main Content */}
-          <div className="lg:col-span-3 order-1 lg:order-2">
-            {children}
-
-            <div className="my-12">
-              <AdsterraAds format="native" className="max-w-2xl mx-auto" />
-            </div>
-          </div>
+      <div className="border-t border-border/30 bg-white/90 py-10 backdrop-blur">
+        <div className="mx-auto flex max-w-sm flex-col items-center gap-3 px-4 text-center">
+          <span className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground/70">
+            Partner Message
+          </span>
+          <MonetizationAds placement="footer" className="mt-0 w-full max-w-[220px]" />
         </div>
       </div>
-
-      {/* Footer Ad */}
-      <div className="w-full bg-muted/30 py-4 mt-12">
-        <div className="container mx-auto px-4">
-          <MonetizationAds placement="footer" />
-        </div>
-      </div>
-
-      {/* Mobile-specific ads */}
-      <div className="block lg:hidden">
-        <div className="fixed bottom-20 left-4 right-4 z-40">
-          <MonetizationAds placement="mobile" />
-        </div>
-      </div>
-
-      {/* Social Bar */}
-      <AdsterraAds format="social-bar" />
     </div>
   );
 };

--- a/src/components/PricingTransparency.tsx
+++ b/src/components/PricingTransparency.tsx
@@ -1,0 +1,181 @@
+import { useState } from "react";
+import { Coins, LineChart, ShieldCheck } from "lucide-react";
+
+import { useLanguage } from "@/contexts/LanguageContext";
+
+type Audience = "creators" | "enterprise";
+
+const tiers: Record<Audience, {
+  headlineEn: string;
+  headlineBn: string;
+  price: string;
+  priceBn: string;
+  descriptionEn: string;
+  descriptionBn: string;
+  features: string[];
+  featuresBn: string[];
+  cta: string;
+  ctaBn: string;
+}> = {
+  creators: {
+    headlineEn: "Creator revenue share",
+    headlineBn: "ক্রিয়েটর রেভিনিউ শেয়ার",
+    price: "Keep up to 80%",
+    priceBn: "৮০% পর্যন্ত আপনার",
+    descriptionEn:
+      "No listing fees. Automated royalty forecasts. Instant dashboards for payouts across USD, BDT, EUR, SAR.",
+    descriptionBn:
+      "লিস্টিং ফি নেই। স্বয়ংক্রিয় রয়্যালটি পূর্বাভাস। USD, BDT, EUR, SAR এ তাৎক্ষণিক পেআউট ড্যাশবোর্ড।",
+    features: [
+      "Dynamic pricing guidance", "72-hour payout commitment", "Collaboration rooms with legal templates",
+    ],
+    featuresBn: [
+      "ডায়নামিক প্রাইসিং নির্দেশিকা", "৭২ ঘণ্টায় পেমেন্ট নিশ্চিত", "লিগ্যাল টেমপ্লেটসহ সহযোগিতা স্পেস",
+    ],
+    cta: "Join as creator",
+    ctaBn: "ক্রিয়েটর হিসেবে যোগ দিন",
+  },
+  enterprise: {
+    headlineEn: "Enterprise localisation suite",
+    headlineBn: "এন্টারপ্রাইজ লোকালাইজেশন স্যুইট",
+    price: "Custom annual partnership",
+    priceBn: "কাস্টম বার্ষিক পার্টনারশিপ",
+    descriptionEn:
+      "Dedicated curator pods, compliance vaults, and co-marketing launches across 70+ countries.",
+    descriptionBn:
+      "ডেডিকেটেড কিউরেটর টিম, কমপ্লায়েন্স ভল্ট ও ৭০+ দেশে কো-মার্কেটিং লঞ্চ।",
+    features: [
+      "Global prompt orchestration", "Governance workshops", "Executive analytics briefings",
+    ],
+    featuresBn: [
+      "গ্লোবাল প্রম্পট অর্কেস্ট্রেশন", "গভর্নেন্স ওয়ার্কশপ", "এক্সিকিউটিভ অ্যানালিটিক্স ব্রিফিং",
+    ],
+    cta: "Book enterprise session",
+    ctaBn: "এন্টারপ্রাইজ সেশন বুক করুন",
+  },
+};
+
+const PricingTransparency = () => {
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+  const [audience, setAudience] = useState<Audience>("creators");
+  const tier = tiers[audience];
+  const tierHeadline = isEnglish ? tier.headlineEn : tier.headlineBn;
+  const tierPrice = isEnglish ? tier.price : tier.priceBn;
+  const tierDescription = isEnglish ? tier.descriptionEn : tier.descriptionBn;
+  const tierFeatures = isEnglish ? tier.features : tier.featuresBn;
+  const tierCta = isEnglish ? tier.cta : tier.ctaBn;
+
+  return (
+    <section id="pricing" className="section bg-gradient-to-b from-primary/5 via-transparent to-background">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="text-center">
+          <p className="section-eyebrow">{isEnglish ? "Pricing & Revenue Transparency" : "প্রাইসিং ও রেভিনিউ স্বচ্ছতা"}</p>
+          <h2 className="section-heading">
+            {isEnglish
+              ? "Predictable economics for every collaborator."
+              : "প্রত্যেক অংশীদারের জন্য পূর্বানুমানযোগ্য অর্থনীতি।"}
+          </h2>
+          <p className="section-subheading mx-auto mt-6">
+            {isEnglish
+              ? "Designed for prompt sellers and enterprise buyers alike—clear splits, zero hidden fees, and proactive growth insights."
+              : "প্রম্পট নির্মাতা ও এন্টারপ্রাইজ ক্রেতা—দু’পক্ষের জন্যই স্বচ্ছ ভাগাভাগি, কোন গোপন চার্জ নয় এবং অগ্রগতির পূর্বাভাস।"}
+          </p>
+        </div>
+
+        <div className="mt-12 flex justify-center gap-4">
+          <button
+            type="button"
+            onClick={() => setAudience("creators")}
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-all ${
+              audience === "creators"
+                ? "bg-primary text-white shadow-[var(--shadow-soft)]"
+                : "bg-white text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {isEnglish ? "Creators" : "ক্রিয়েটরস"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setAudience("enterprise")}
+            className={`rounded-full px-5 py-2 text-sm font-semibold transition-all ${
+              audience === "enterprise"
+                ? "bg-primary text-white shadow-[var(--shadow-soft)]"
+                : "bg-white text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {isEnglish ? "Enterprise" : "এন্টারপ্রাইজ"}
+          </button>
+        </div>
+
+        <div className="mt-12 grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
+          <div className="rounded-[2rem] border border-white/60 bg-white/80 p-8 shadow-[var(--shadow-soft)] backdrop-blur">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.3em] text-muted-foreground">{tierHeadline}</p>
+              </div>
+              <Coins className="h-6 w-6 text-primary" />
+            </div>
+
+            <div className="mt-6">
+              <p className="text-3xl font-semibold text-foreground">{tierPrice}</p>
+            </div>
+
+            <p className="mt-6 text-sm leading-relaxed text-muted-foreground">{tierDescription}</p>
+
+            <div className="mt-8 grid gap-3 text-sm text-muted-foreground">
+              {tierFeatures.map((feature) => (
+                <div key={feature} className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
+                  <p className="text-foreground">{feature}</p>
+                </div>
+              ))}
+            </div>
+
+            <a
+              href={audience === "creators" ? "/community/submit" : "#enterprise"}
+              className="mt-8 inline-flex items-center justify-center rounded-full bg-[var(--gradient-aurora)] px-6 py-3 text-sm font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+            >
+              {tierCta}
+            </a>
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex items-center gap-3">
+                <LineChart className="h-6 w-6 text-secondary" />
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isEnglish ? "Predictive royalty modeling" : "প্রেডিক্টিভ রয়্যালটি মডেলিং"}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-sm text-muted-foreground">
+                {isEnglish
+                  ? "See future payout trends before you launch. Toggle between USD, BDT, EUR, and SAR projections in a single pane."
+                  : "লঞ্চের আগেই পেআউট ট্রেন্ড দেখে নিন। USD, BDT, EUR ও SAR পূর্বাভাস একসাথে পর্যবেক্ষণ করুন।"}
+              </p>
+            </div>
+
+            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex items-center gap-3">
+                <ShieldCheck className="h-6 w-6 text-primary" />
+                <div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {isEnglish ? "Fairness charter" : "ফেয়ারনেস চার্টার"}
+                  </p>
+                </div>
+              </div>
+              <p className="mt-3 text-sm text-muted-foreground">
+                {isEnglish
+                  ? "Transparent dispute resolution, co-creation credits, and legal-safe collaboration agreements."
+                  : "স্বচ্ছ বিরোধ নিষ্পত্তি, কো-ক্রিয়েশন ক্রেডিট এবং আইন-সম্মত সহযোগিতা চুক্তি।"}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PricingTransparency;

--- a/src/components/PromptTemplates.tsx
+++ b/src/components/PromptTemplates.tsx
@@ -1,99 +1,221 @@
+import { useState } from "react";
+import { PlayCircle, Sparkles, TrendingUp } from "lucide-react";
 
-import React from 'react';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Copy, FileText, MessageSquare, PenTool } from 'lucide-react';
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const creators = [
+  {
+    id: "aurora",
+    name: "Aurora Studio",
+    nameBn: "অরোরা স্টুডিও",
+    location: "Dhaka → Singapore",
+    locationBn: "ঢাকা → সিঙ্গাপুর",
+    industry: "Enterprise brand storytelling",
+    industryBn: "এন্টারপ্রাইজ ব্র্যান্ড স্টোরিটেলিং",
+    quoteEn:
+      "We staged a multilingual product launch for a Southeast Asian telco in six days—Bangla nuance intact, enterprise compliance satisfied.",
+    quoteBn:
+      "মাত্র ছয় দিনে আমরা একটি দক্ষিণ-পূর্ব এশীয় টেলকোর জন্য বহুভাষিক প্রোডাক্ট লঞ্চ প্রস্তুত করেছি—বাংলা সূক্ষ্মতা বজায় রেখেই এন্টারপ্রাইজ কমপ্লায়েন্স সম্পন্ন।",
+    revenue: "$38K in 90 days",
+    revenueBn: "৯০ দিনে $৩৮ হাজার",
+    prompts: "63 premium prompts",
+    promptsBn: "৬৩টি প্রিমিয়াম প্রম্পট",
+    sectors: "Telecom • OTT • Public Sector",
+    sectorsBn: "টেলিকম • ওটিটি • পাবলিক সেক্টর",
+  },
+  {
+    id: "luminous",
+    name: "Luminous Labs",
+    nameBn: "লুমিনাস ল্যাবস",
+    location: "Chattogram → New York",
+    locationBn: "চট্টগ্রাম → নিউ ইয়র্ক",
+    industry: "Financial services automation",
+    industryBn: "ফাইন্যান্সিয়াল সার্ভিস অটোমেশন",
+    quoteEn:
+      "Predictive royalty forecasting gave us confidence to scale pricing while staying fair to diaspora SMEs.",
+    quoteBn:
+      "প্রেডিক্টিভ রয়্যালটি পূর্বাভাস আমাদের দাম বাড়াতে সাহস দিয়েছে—প্রবাসী এসএমইদের প্রতি ন্যায্য থেকেও।",
+    revenue: "$22K recurring",
+    revenueBn: "মাসিক পুনরাবৃত্ত $২২ হাজার",
+    prompts: "41 regulatory prompts",
+    promptsBn: "৪১টি রেগুলেটরি প্রম্পট",
+    sectors: "Fintech • Microfinance • Islamic Banking",
+    sectorsBn: "ফিনটেক • মাইক্রোফাইন্যান্স • ইসলামিক ব্যাংকিং",
+  },
+  {
+    id: "canvas",
+    name: "Canvas Collective",
+    nameBn: "ক্যানভাস কালেকটিভ",
+    location: "Rajshahi → London",
+    locationBn: "রাজশাহী → লন্ডন",
+    industry: "Media localisation",
+    industryBn: "মিডিয়া লোকালাইজেশন",
+    quoteEn:
+      "Our cinematic prompts now run in 14 countries. Revenue split transparency keeps every collaborator inspired.",
+    quoteBn:
+      "আমাদের সিনেমাটিক প্রম্পট এখন ১৪ দেশে ব্যবহৃত। স্বচ্ছ রেভিনিউ ভাগাভাগি প্রতিটি সহযোগীকে অনুপ্রাণিত রাখে।",
+    revenue: "$29K hybrid",
+    revenueBn: "হাইব্রিড আয় $২৯ হাজার",
+    prompts: "52 streaming prompts",
+    promptsBn: "৫২টি স্ট্রিমিং প্রম্পট",
+    sectors: "Broadcast • Streaming • Culture",
+    sectorsBn: "ব্রডকাস্ট • স্ট্রিমিং • সংস্কৃতি",
+  },
+];
+
+const highlightItems = [
+  { en: "Prompt Commerce Cohort 2025", bn: "প্রম্পট কমার্স কোহর্ট ২০২৫" },
+  { en: "72h payout track record", bn: "৭২ ঘণ্টার পেআউট রেকর্ড" },
+  { en: "Global rights-managed catalog", bn: "গ্লোবাল রাইটস-ম্যানেজড ক্যাটালগ" },
+];
+
+const operatingSystemFeatures = [
+  {
+    en: "360° analytics dashboard",
+    bn: "৩৬০° অ্যানালিটিক্স ড্যাশবোর্ড",
+  },
+  {
+    en: "Trust badges & SOC 2 documentation",
+    bn: "ট্রাস্ট ব্যাজ ও SOC 2 ডকুমেন্টেশন",
+  },
+  {
+    en: "Royalty simulator with currency switch",
+    bn: "কারেন্সি সুইচসহ রয়্যালটি সিমুলেটর",
+  },
+];
 
 const PromptTemplates = () => {
-  const templates = [
-    {
-      icon: FileText,
-      title: 'বিষয়বস্তু লেখার টেমপ্লেট',
-      description: 'ব্লগ পোস্ট, আর্টিকেল এবং কন্টেন্ট তৈরির জন্য',
-      template: `আপনি একজন অভিজ্ঞ কন্টেন্ট রাইটার। আমি যে বিষয়ে লিখতে চাই সেটি হল: [বিষয়]
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+  const [activeCreatorId, setActiveCreatorId] = useState(creators[0].id);
 
-দয়া করে নিম্নলিখিত কাঠামো অনুসরণ করুন:
-1. আকর্ষণীয় শিরোনাম
-2. সূচনা প্যারাগ্রাফ
-3. মূল বিষয়বস্তু (৩-৫টি পয়েন্ট)
-4. উপসংহার
-
-লেখার স্টাইল: [আনুষ্ঠানিক/অনানুষ্ঠানিক]
-শব্দ সীমা: [সংখ্যা] শব্দ`
-    },
-    {
-      icon: MessageSquare,
-      title: 'কথোপকথনের টেমপ্লেট',
-      description: 'AI এর সাথে কার্যকর কথোপকথনের জন্য',
-      template: `আমি [আপনার পরিচয়/ভূমিকা] হিসেবে আপনার সাথে কথা বলছি।
-
-আমার প্রশ্ন/সমস্যা: [বিস্তারিত বর্ণনা]
-
-আমি চাই আপনি:
-- [নির্দিষ্ট অনুরোধ ১]
-- [নির্দিষ্ট অনুরোধ ২]
-- [নির্দিষ্ট অনুরোধ ৩]
-
-উত্তর দেওয়ার সময় দয়া করে [বিশেষ নির্দেশনা] মনে রাখবেন।`
-    },
-    {
-      icon: PenTool,
-      title: 'সৃজনশীল লেখার টেমপ্লেট',
-      description: 'গল্প, কবিতা এবং সৃজনশীল কাজের জন্য',
-      template: `আপনি একজন দক্ষ সৃজনশীল লেখক। আমি চাই আপনি একটি [গল্প/কবিতা/স্ক্রিপ্ট] লিখুন।
-
-বিষয়: [মূল থিম]
-পরিবেশ: [সময় এবং স্থান]
-চরিত্র: [প্রধান চরিত্রের বর্ণনা]
-মেজাজ: [হাসি/গম্ভীর/রোমান্টিক/রহস্যময়]
-
-অতিরিক্ত নির্দেশনা:
-- [বিশেষ প্রয়োজনীয়তা]
-- দৈর্ঘ্য: [শব্দ/পৃষ্ঠা সংখ্যা]`
-    }
-  ];
-
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard.writeText(text);
-  };
+  const activeCreator = creators.find((creator) => creator.id === activeCreatorId) ?? creators[0];
 
   return (
-    <section id="prompt-templates" className="py-20 bg-white">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl font-bold font-bengali text-gray-900 mb-4">
-            প্রম্পট টেমপ্লেট সংগ্রহ
-          </h2>
-          <p className="text-xl text-gray-600 font-bengali max-w-3xl mx-auto">
-            তৈরি টেমপ্লেট ব্যবহার করে আরও কার্যকর প্রম্পট লিখুন
-          </p>
-        </div>
+    <section id="creators" className="section">
+      <div className="mx-auto max-w-7xl px-4 md:px-8">
+        <div className="grid gap-12 lg:grid-cols-[1.15fr_0.85fr]">
+          <div className="space-y-8">
+            <p className="section-eyebrow">{isEnglish ? "Creator Success Stories" : "ক্রিয়েটর সফলতার গল্প"}</p>
+            <h2 className="section-heading">
+              {isEnglish ? "From Dhaka studios to global boardrooms." : "ঢাকার স্টুডিও থেকে বিশ্বব্যাপী বোর্ডরুমে।"}
+            </h2>
+            <p className="section-subheading">
+              {isEnglish
+                ? "Spotlight journeys showing how Bengali prompt creators package expertise, grow recurring revenue, and earn trust from international buyers."
+                : "বাংলাভাষী প্রম্পট নির্মাতারা কীভাবে অভিজ্ঞতাকে প্যাকেজ করছেন, পুনরাবৃত্ত আয় বাড়াচ্ছেন এবং বৈশ্বিক ক্রেতাদের আস্থা অর্জন করছেন—সেসব বাস্তব যাত্রার আলোকপাত।"}
+            </p>
 
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-          {templates.map((template, index) => (
-            <Card key={index} className="h-full flex flex-col">
-              <CardHeader>
-                <template.icon className="w-10 h-10 text-green-600 mb-3" />
-                <CardTitle className="font-bengali">{template.title}</CardTitle>
-                <CardDescription className="font-bengali">
-                  {template.description}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="flex-grow">
-                <div className="bg-gray-50 p-4 rounded-lg mb-4 text-sm font-mono text-gray-700 max-h-48 overflow-y-auto">
-                  {template.template}
+            <div className="glass-panel rounded-[2rem] p-8">
+              <div className="flex flex-wrap items-center gap-3 text-xs font-semibold uppercase tracking-[0.25em] text-muted-foreground">
+                <Sparkles className="h-4 w-4 text-primary" />
+                {highlightItems.map((item, index) => (
+                  <span key={item.en} className="flex items-center gap-3 text-muted-foreground">
+                    <span>{isEnglish ? item.en : item.bn}</span>
+                    {index < highlightItems.length - 1 && (
+                      <span className="text-muted-foreground/60">•</span>
+                    )}
+                  </span>
+                ))}
+              </div>
+
+              <div className="mt-6 rounded-2xl border border-muted-foreground/20 bg-background/80 p-6 shadow-sm">
+                <h3 className="text-lg font-semibold text-foreground">
+                  {isEnglish ? activeCreator.name : activeCreator.nameBn}
+                </h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {isEnglish ? activeCreator.location : activeCreator.locationBn}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {isEnglish ? activeCreator.industry : activeCreator.industryBn}
+                </p>
+
+                <blockquote className="mt-6 border-l-4 border-primary/60 pl-4 text-sm leading-relaxed text-foreground">
+                  “{isEnglish ? activeCreator.quoteEn : activeCreator.quoteBn}”
+                </blockquote>
+
+                <div className="mt-6 grid gap-4 sm:grid-cols-3">
+                  <div className="rounded-2xl bg-primary/10 p-4 text-sm font-medium text-primary">
+                    <p className="text-foreground">
+                      {isEnglish ? activeCreator.revenue : activeCreator.revenueBn}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-secondary/20 p-4 text-sm font-medium text-secondary">
+                    <p className="text-foreground">
+                      {isEnglish ? activeCreator.prompts : activeCreator.promptsBn}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl bg-accent/15 p-4 text-sm font-medium text-accent">
+                    <p className="text-foreground">
+                      {isEnglish ? activeCreator.sectors : activeCreator.sectorsBn}
+                    </p>
+                  </div>
                 </div>
-                <Button 
-                  onClick={() => copyToClipboard(template.template)}
-                  className="w-full"
-                  variant="outline"
-                >
-                  <Copy className="w-4 h-4 mr-2" />
-                  কপি করুন
-                </Button>
-              </CardContent>
-            </Card>
-          ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <div className="flex items-center justify-between">
+                <h3 className="text-base font-semibold text-foreground">
+                  {isEnglish ? "Select a creator journey" : "একজন ক্রিয়েটরের যাত্রা বেছে নিন"}
+                </h3>
+                <TrendingUp className="h-5 w-5 text-primary" />
+              </div>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {isEnglish
+                  ? "Choose from the spotlight journeys to explore playbooks, revenue dashboards, and enterprise references."
+                  : "স্পটলাইট জার্নি বেছে নিয়ে প্লেবুক, রেভিনিউ ড্যাশবোর্ড ও এন্টারপ্রাইজ রেফারেন্স দেখুন।"}
+              </p>
+
+              <div className="mt-6 grid gap-3">
+                {creators.map((creator) => {
+                  const isActive = creator.id === activeCreatorId;
+                  return (
+                    <button
+                      key={creator.id}
+                      type="button"
+                      onClick={() => setActiveCreatorId(creator.id)}
+                      className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-left transition-all ${
+                        isActive
+                          ? "border-transparent bg-primary text-white shadow-[var(--shadow-soft)]"
+                          : "border-muted-foreground/30 bg-white/50 text-foreground hover:border-muted-foreground/60"
+                      }`}
+                    >
+                      <div>
+                        <p className="text-sm font-semibold">
+                          {isEnglish ? creator.name : creator.nameBn}
+                        </p>
+                        <p className={`text-xs ${isActive ? "text-white/80" : "text-muted-foreground"}`}>
+                          {isEnglish ? creator.location : creator.locationBn}
+                        </p>
+                      </div>
+                      <PlayCircle className="h-5 w-5" />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="rounded-[2rem] border border-white/70 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <h3 className="text-base font-semibold text-foreground">
+                {isEnglish ? "Creator Operating System" : "ক্রিয়েটর অপারেটিং সিস্টেম"}
+              </h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {isEnglish
+                  ? "Access revenue forecasting, compliance vaults, and co-marketing playbooks curated for Bengali-first storytellers."
+                  : "বাঙালি গল্পকারদের জন্য রেভিনিউ পূর্বাভাস, কমপ্লায়েন্স ভল্ট ও কো-মার্কেটিং প্লেবুক এখন এক প্ল্যাটফর্মে।"}
+              </p>
+              <div className="mt-4 grid gap-3 text-sm text-muted-foreground">
+                {operatingSystemFeatures.map((feature) => (
+                  <div key={feature.en} className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-3">
+                    {isEnglish ? feature.en : feature.bn}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -10,11 +10,12 @@ interface SEOHeadProps {
 }
 
 const SEOHead: React.FC<SEOHeadProps> = ({
-  title = "প্রম্পট শিক্ষা - বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন",
-  description = "বাংলায় প্রম্পট ইঞ্জিনিয়ারিং শিখুন। বিশেষজ্ঞ-ডিজাইন করা কোর্সগুলি আপনাকে AI মডেলগুলির সাথে কার্যকরভাবে যোগাযোগ করতে সাহায্য করবে।",
-  keywords = "প্রম্পট ইঞ্জিনিয়ারিং, বাংলা AI কোর্স, ChatGPT বাংলা, AI শিক্ষা",
+  title = "BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace",
+  description =
+    "Launch bilingual prompt storefronts, sell culturally rich AI workflows, and reach verified global buyers with transparent revenue tools and enterprise compliance.",
+  keywords = "BanglaPrompt.ai, Bengali AI prompts, sell prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation",
   image = "/og-image.png",
-  url = "https://promptshiksha.com/"
+  url = "https://banglaprompt.ai/"
 }) => {
   return (
     <Helmet>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+export type LanguageCode = "en" | "bn";
+
+interface LanguageContextValue {
+  language: LanguageCode;
+  setLanguage: (language: LanguageCode) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export const LanguageProvider = ({ children }: { children: React.ReactNode }) => {
+  const [language, setLanguage] = useState<LanguageCode>(() => {
+    if (typeof window === "undefined") {
+      return "en";
+    }
+
+    const stored = window.localStorage.getItem("banglaprompt-language");
+    return stored === "bn" ? "bn" : "en";
+  });
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      document.documentElement.lang = language;
+    }
+
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("banglaprompt-language", language);
+    }
+  }, [language]);
+
+  const value = useMemo(
+    () => ({
+      language,
+      setLanguage,
+    }),
+    [language],
+  );
+
+  return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error("useLanguage must be used within a LanguageProvider");
+  }
+
+  return context;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,51 +1,56 @@
-
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
-    /* Bangladeshi Cultural Colors */
-    --bd-green: 140 76% 29%; /* Bangladesh flag green */
-    --bd-red: 348 95% 48%; /* Bangladesh flag red */
-    --bd-gold: 45 93% 58%; /* Traditional Bengali gold */
-    --bd-crimson: 350 84% 40%; /* Deep red for prosperity */
-    --bd-emerald: 140 60% 35%; /* Rich green for nature */
-    
-    --background: 210 20% 98%;
-    --foreground: 222 47% 11%;
+    --bd-green: 140 76% 29%;
+    --bd-red: 348 95% 48%;
+    --bd-gold: 45 93% 58%;
+    --bd-crimson: 350 84% 40%;
+    --bd-emerald: 140 60% 35%;
+
+    --charcoal: 222 47% 11%;
+    --cloud: 210 20% 98%;
+    --emerald: 140 76% 29%;
+    --sungold: 45 93% 58%;
+    --sky: 348 95% 48%;
+
+    --background: var(--cloud);
+    --foreground: var(--charcoal);
+
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
+    --card-foreground: var(--charcoal);
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
-    --primary: var(--bd-green); /* Using Bangladesh green */
+    --popover-foreground: var(--charcoal);
+    --primary: var(--emerald);
     --primary-foreground: 210 40% 98%;
-    --secondary: var(--bd-gold); /* Using Bengali gold */
-    --secondary-foreground: 222 47% 11%;
+    --secondary: var(--sungold);
+    --secondary-foreground: var(--charcoal);
     --muted: 210 40% 96%;
     --muted-foreground: 215 16% 47%;
-    --accent: var(--bd-red); /* Using Bangladesh red */
+    --accent: var(--sky);
     --accent-foreground: 210 40% 98%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
     --border: 214 32% 91%;
     --input: 214 32% 91%;
-    --ring: var(--bd-green);
-    --radius: 0.5rem;
-    
-    /* Custom variables for the site */
+    --ring: var(--emerald);
+    --radius: 0.75rem;
+
     --highlight: 261 100% 65%;
     --highlight-foreground: 0 0% 100%;
-    
-    /* Cultural gradients */
-    --gradient-bangladesh: linear-gradient(135deg, hsl(var(--bd-green)), hsl(var(--bd-red)));
-    --gradient-prosperity: linear-gradient(135deg, hsl(var(--bd-gold)), hsl(var(--bd-crimson)));
-    --gradient-nature: linear-gradient(135deg, hsl(var(--bd-emerald)), hsl(var(--bd-green)));
-    
-    /* Traditional shadows */
-    --shadow-cultural: 0 10px 30px -10px hsl(var(--bd-green) / 0.3);
-    --shadow-prosperity: 0 0 40px hsl(var(--bd-gold) / 0.4);
+
+    --gradient-bangladesh: linear-gradient(135deg, hsl(var(--emerald)), hsl(var(--sky)));
+    --gradient-prosperity: linear-gradient(135deg, hsl(var(--sungold)), hsl(var(--bd-crimson)));
+    --gradient-nature: linear-gradient(135deg, hsl(var(--bd-emerald)), hsl(var(--emerald)));
+    --gradient-aurora: linear-gradient(135deg, hsl(var(--emerald)) 0%, hsl(var(--sungold)) 48%, hsl(var(--sky)) 100%);
+    --gradient-midnight: linear-gradient(135deg, rgba(31, 56, 43, 0.92), rgba(96, 20, 20, 0.9));
+
+    --shadow-cultural: 0 10px 30px -10px hsl(var(--emerald) / 0.35);
+    --shadow-prosperity: 0 0 40px hsl(var(--sungold) / 0.4);
+    --shadow-elevated: 0 30px 60px -24px rgba(31, 56, 43, 0.45);
+    --shadow-soft: 0 18px 36px -20px rgba(31, 56, 43, 0.28);
   }
 
   .dark {
@@ -55,19 +60,17 @@
     --card-foreground: 210 40% 98%;
     --popover: 222 47% 11%;
     --popover-foreground: 210 40% 98%;
-    --primary: var(--bd-green);
+    --primary: var(--emerald);
     --primary-foreground: 222 47% 11%;
-    --secondary: var(--bd-gold);
+    --secondary: var(--sungold);
     --secondary-foreground: 210 40% 98%;
     --muted: 217 33% 17%;
     --muted-foreground: 215 20% 65%;
-    --accent: var(--bd-red);
+    --accent: var(--sky);
     --accent-foreground: 210 40% 98%;
-    --destructive: 0 63% 31%;
-    --destructive-foreground: 210 40% 98%;
     --border: 217 33% 17%;
     --input: 217 33% 17%;
-    --ring: 224 76% 48%;
+    --ring: var(--emerald);
   }
 }
 
@@ -81,150 +84,85 @@
     background-image: url("data:image/svg+xml,%3Csvg width='52' height='26' viewBox='0 0 52 26' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='none' fill-rule='evenodd'%3E%3Cg fill='%23d97706' fill-opacity='0.15'%3E%3Cpath d='M10 10c0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6h2c0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4 3.314 0 6 2.686 6 6 0 2.21 1.79 4 4 4v2c-3.314 0-6-2.686-6-6 0-2.21-1.79-4-4-4-3.314 0-6-2.686-6-6zm25.464-1.95l8.486 8.486-1.414 1.414-8.486-8.486 1.414-1.414z' /%3E%3C/g%3E%3C/g%3E%3C/svg%3E");
   }
 
-  /* Smooth scrolling */
   html {
     scroll-behavior: smooth;
   }
 
-  /* Custom scroll bar */
+  ::selection {
+    background: hsl(var(--sungold) / 0.4);
+    color: hsl(var(--charcoal));
+  }
+
   ::-webkit-scrollbar {
     width: 12px;
   }
 
   ::-webkit-scrollbar-track {
-    @apply bg-amber-100;
+    background: hsl(var(--sungold) / 0.1);
   }
 
   ::-webkit-scrollbar-thumb {
-    @apply bg-amber-500 border-2 border-amber-700;
+    background: hsl(var(--sungold));
+    border: 2px solid hsl(var(--emerald));
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    @apply bg-amber-600;
+    background: hsl(var(--sungold) / 0.9);
   }
 }
 
 @layer components {
-  .glass {
-    @apply bg-white/90 backdrop-blur-md border-2 border-amber-400 shadow-retro;
-  }
-  
-  .highlight-text {
-    @apply text-transparent bg-clip-text bg-gradient-to-r from-amber-600 to-orange-500 font-bold font-mono;
-  }
-  
-  .btn-primary {
-    @apply px-6 py-3 rounded-lg bg-gradient-to-r from-amber-500 to-orange-500 text-white font-bold font-mono transition-all duration-300 hover:shadow-lg border-2 border-amber-700 shadow-retro active:translate-x-1 active:translate-y-1 active:shadow-none;
-  }
-  
-  .btn-secondary {
-    @apply px-6 py-3 rounded-lg bg-white text-amber-800 border-2 border-amber-600 font-mono font-bold shadow-retro transition-all duration-300 hover:bg-amber-50 active:translate-x-1 active:translate-y-1 active:shadow-none;
-  }
-  
-  .heading {
-    @apply text-4xl sm:text-5xl md:text-6xl font-mono font-bold;
-  }
-  
-  .subheading {
-    @apply text-xl sm:text-2xl text-amber-900/80 font-bengali font-normal max-w-3xl;
-  }
-  
-  .card {
-    @apply bg-white rounded-xl border-2 border-amber-600 shadow-retro overflow-hidden transition-all duration-300 hover:shadow-retro-amber;
-  }
-  
   .section {
-    @apply py-16 md:py-24;
+    @apply py-20 md:py-28;
   }
 
-  .retro-pattern {
-    background-color: #f5f5f5;
-    background-image: url("data:image/svg+xml,%3Csvg width='20' height='20' viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%23d97706' fill-opacity='0.2' fill-rule='evenodd'%3E%3Ccircle cx='3' cy='3' r='3'/%3E%3Ccircle cx='13' cy='13' r='3'/%3E%3C/g%3E%3C/svg%3E");
+  .section-heading {
+    @apply text-3xl md:text-4xl lg:text-5xl font-semibold tracking-tight text-foreground;
   }
-  
-  /* 90s cartoon style elements */
-  .cartoon-border {
-    @apply border-4 border-dashed border-purple-600 p-2 rounded-xl;
-    box-shadow: 5px 5px 0px #8B5CF6, 10px 10px 0px #EC4899;
-  }
-  
-  .cartoon-title {
-    @apply font-bengali font-bold text-5xl sm:text-6xl md:text-7xl text-center;
-    text-shadow: 3px 3px 0px #F97316, 6px 6px 0px #8B5CF6;
-    -webkit-text-stroke: 2px #000;
-  }
-  
-  .cartoon-subtitle {
-    @apply font-bengali font-semibold text-xl sm:text-2xl md:text-3xl;
-    text-shadow: 2px 2px 0px #F97316;
-  }
-  
-  .cartoon-button {
-    @apply relative font-bengali font-bold text-lg py-3 px-6 rounded-xl bg-gradient-to-r from-orange-400 to-rose-500 text-white border-4 border-black hover:from-rose-500 hover:to-orange-400 transition-all;
-    box-shadow: 5px 5px 0px #000;
-  }
-  
-  .cartoon-button:active {
-    @apply translate-x-1 translate-y-1;
-    box-shadow: 2px 2px 0px #000;
-  }
-  
-  .cartoon-card {
-    @apply rounded-xl border-4 border-black p-6 bg-gradient-to-br from-amber-100 to-amber-200;
-    box-shadow: 8px 8px 0px #000;
-  }
-  
-  .cartoon-wiggle {
-    animation: wiggle 2s ease-in-out infinite;
-  }
-  
-  @keyframes wiggle {
-    0%, 100% { transform: rotate(-3deg); }
-    50% { transform: rotate(3deg); }
-  }
-}
 
-/* Google Ad Styles */
-.google-ad {
-  @apply my-6 p-4 bg-white border-4 border-black rounded-lg shadow-retro overflow-hidden;
-  box-shadow: 5px 5px 0px #000;
-}
+  .section-subheading {
+    @apply text-lg md:text-xl text-muted-foreground max-w-2xl;
+  }
 
-/* Retro underline */
-.retro-underline {
-  @apply relative;
-}
+  .section-eyebrow {
+    @apply uppercase tracking-[0.2em] text-xs font-semibold text-primary/80 mb-4;
+  }
 
-.retro-underline::after {
-  content: '';
-  @apply absolute left-0 -bottom-1 w-full h-2 bg-amber-400 -z-10;
-  transform: rotate(-1deg);
-}
+  .pill {
+    @apply inline-flex items-center gap-2 rounded-full px-4 py-2 bg-primary/10 text-primary text-sm font-medium;
+  }
 
-/* Typewriter effect */
-.typewriter {
-  @apply overflow-hidden whitespace-nowrap border-r-4 border-amber-800 animate-typewriter;
-}
+  .stat-card {
+    @apply rounded-2xl bg-white shadow-[var(--shadow-soft)] p-6 border border-white/60 backdrop-blur;
+  }
 
+  .bilingual-grid {
+    @apply grid gap-8 lg:gap-12 lg:grid-cols-2;
+  }
 
-/* Bengali Typography Enhancements */
-.font-bengali {
-  font-family: 'Noto Sans Bengali', 'Hind Siliguri', sans-serif;
-  line-height: 1.7;
-  letter-spacing: 0.01em;
-}
+  .bilingual-copy {
+    @apply text-base md:text-lg leading-relaxed text-muted-foreground;
+  }
 
-/* Cultural Design Elements */
-.bangladesh-pattern {
-  background-image: 
-    radial-gradient(circle at 25% 25%, hsl(var(--bd-green) / 0.1) 0%, transparent 50%),
-    radial-gradient(circle at 75% 75%, hsl(var(--bd-red) / 0.1) 0%, transparent 50%);
-}
+  .gradient-border {
+    position: relative;
+  }
 
-.cultural-card {
-  background: linear-gradient(135deg, 
-    hsl(var(--background)) 0%, 
-    hsl(var(--bd-green) / 0.02) 100%);
-  border: 1px solid hsl(var(--bd-green) / 0.2);
-  box-shadow: var(--shadow-cultural);
+  .gradient-border::after {
+    content: "";
+    position: absolute;
+    inset: -1px;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, rgba(34, 94, 56, 0.7), rgba(217, 119, 6, 0.6), rgba(239, 68, 68, 0.55));
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+            mask-composite: exclude;
+    pointer-events: none;
+  }
+
+  .glass-panel {
+    @apply bg-white/90 backdrop-blur-xl border border-white/70;
+    box-shadow: var(--shadow-cultural);
+  }
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,15 +8,20 @@ import Hero from "@/components/Hero";
 import Features from "@/components/Features";
 import OptimizedAdLayout from "@/components/OptimizedAdLayout";
 import CookieConsent from "@/components/CookieConsent";
-import { 
-  LazyAdvancedPatterns, 
-  LazyPromptTemplates, 
-  LazyAbout, 
+import {
+  LazyAdvancedPatterns,
+  LazyPromptTemplates,
+  LazyAbout,
   LazyContact,
   LazyMediumSubscriptionPopup,
   LazyNewsletterConversionPopup
 } from "@/components/LazyComponents";
 import Footer from "@/components/Footer";
+import PricingTransparency from "@/components/PricingTransparency";
+import GlobalCommunity from "@/components/GlobalCommunity";
+import InsightsHub from "@/components/InsightsHub";
+import FinalCTA from "@/components/FinalCTA";
+import { LanguageProvider } from "@/contexts/LanguageContext";
 
 // Loading fallback component
 const LoadingFallback = () => (
@@ -30,33 +35,41 @@ const Index = () => {
   useAnalytics();
   
   return (
-    <div className="min-h-screen">
-      <SEOHead />
-      <SecurityHeaders />
-      <PerformanceOptimizer />
-      
-      <OptimizedAdLayout>
+    <LanguageProvider>
+      <div className="min-h-screen">
+        <SEOHead />
+        <SecurityHeaders />
+        <PerformanceOptimizer />
+
+        <OptimizedAdLayout>
         <Navbar />
         <Hero />
         <Features />
-        
+
         {/* Lazy loaded components for better performance */}
         <Suspense fallback={<LoadingFallback />}>
           <LazyAdvancedPatterns />
         </Suspense>
-        
+
         <Suspense fallback={<LoadingFallback />}>
           <LazyPromptTemplates />
         </Suspense>
-        
+
+        <PricingTransparency />
+
         <Suspense fallback={<LoadingFallback />}>
           <LazyAbout />
         </Suspense>
-        
+
+        <GlobalCommunity />
+        <InsightsHub />
+
         <Suspense fallback={<LoadingFallback />}>
           <LazyContact />
         </Suspense>
-        
+
+        <FinalCTA />
+
         <Footer />
       </OptimizedAdLayout>
       
@@ -71,7 +84,8 @@ const Index = () => {
       <Suspense fallback={null}>
         <LazyNewsletterConversionPopup />
       </Suspense>
-    </div>
+      </div>
+    </LanguageProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- add a language provider that persists the selected locale and wraps the homepage
- update navigation, hero, landing sections, CTAs, popups, and footer so each renders only the active language’s copy
- restore the original amber background treatment from the legacy UI

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68ccbba8488883268ce1c8ed4a9b35fc