### PR TITLE
Fix duplicate navLinks declaration

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Globe2, Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
-const navLinks = [
+const NAV_LINKS = [
   { href: "#marketplace", labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস" },
   { href: "#creators", labelEn: "For Creators", labelBn: "ক্রিয়েটরদের জন্য" },
   { href: "#enterprise", labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ" },
@@ -32,7 +32,7 @@ const Navbar = () => {
   }, [activeLanguage]);
 
   const renderNavLinks = (className?: string) =>
-    navLinks.map((link) => (
+    NAV_LINKS.map((link) => (
       <a
         key={link.href}
         href={link.href}


### PR DESCRIPTION
## Summary
- rename the navbar link collection to NAV_LINKS to avoid duplicate symbol declarations

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd42e29d188326a0f758215bfd923b