### PR TITLE
Fix creator_tools relationship definition

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -74,10 +74,12 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "creator_tools_creator_id_fkey"
-            columns: ["creator_id"]
-            foreignKeyName: "marketplace_prompts_author_id_fkey"
-            columns: ["author_id"]
+            foreignKeyName: "creator_tools_creator_id_fkey",
+            columns: ["creator_id"],
+            isOneToOne: false,
+            referencedRelation: "users",
+            referencedColumns: ["id"],
+            referencedSchema: "auth",
           },
         ]
       }


### PR DESCRIPTION
## Summary
- correct the `creator_tools` relationship metadata to reference `auth.users`

## Testing
- yarn tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cd8a185db883269d40214a54c83cf4