### PR TITLE
Update branding to PromptBazar.AI and refresh CTA styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,17 +8,17 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 
     <!-- Primary Meta Tags -->
-    <title>BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace</title>
-    <meta name="title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <title>PromptBazar.AI – Bangladesh’s first global AI prompt marketplace</title>
+    <meta name="title" content="PromptBazar.AI – Bangladesh’s first global AI prompt marketplace" />
     <meta name="description" content="Launch bilingual prompt storefronts, sell culturally rich AI workflows, and reach verified global buyers with transparent revenue tools and enterprise compliance." />
-    <meta name="keywords" content="BanglaPrompt.ai, Bengali AI prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation" />
-    <meta name="author" content="BanglaPrompt.ai" />
+    <meta name="keywords" content="PromptBazar.AI, BanglaPrompt.ai, Bengali AI prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation" />
+    <meta name="author" content="PromptBazar.AI" />
     <link rel="canonical" href="https://banglaprompt.ai/" />
     
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://banglaprompt.ai/" />
-    <meta property="og:title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <meta property="og:title" content="PromptBazar.AI – Bangladesh’s first global AI prompt marketplace" />
     <meta property="og:description" content="Sell and buy Bengali-first AI prompts with fair revenue splits, bilingual support, and audit-ready governance." />
     <meta property="og:image" content="/og-image.png" />
     <meta property="og:image:width" content="1200" />
@@ -28,7 +28,7 @@
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:url" content="https://banglaprompt.ai/" />
-    <meta property="twitter:title" content="BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace" />
+    <meta property="twitter:title" content="PromptBazar.AI – Bangladesh’s first global AI prompt marketplace" />
     <meta property="twitter:description" content="Sell and buy Bengali-first AI prompts with fair revenue splits, bilingual support, and audit-ready governance." />
     <meta property="twitter:image" content="/og-image.png" />
     
@@ -62,10 +62,10 @@
     {
       "@context": "https://schema.org",
       "@type": "Organization",
-      "name": "BanglaPrompt.ai",
+      "name": "PromptBazar.AI",
       "description": "Bangladesh’s first global AI prompt marketplace with bilingual storefronts and compliant prompt commerce",
       "url": "https://banglaprompt.ai",
-      "logo": "/og-image.png",
+      "logo": "/promptbazar-logo.svg",
       "contactPoint": {
         "@type": "ContactPoint",
         "contactType": "customer service",
@@ -90,7 +90,7 @@
       "description": "Learn to deploy culturally aware prompts for GPT-4.1, Claude 3, and Gemini Ultra across global teams.",
       "provider": {
         "@type": "Organization",
-        "name": "BanglaPrompt.ai"
+        "name": "PromptBazar.AI"
       },
       "inLanguage": ["en", "bn"],
       "courseMode": "online",

--- a/public/promptbazar-logo.svg
+++ b/public/promptbazar-logo.svg
@@ -1,0 +1,48 @@
+<svg width="160" height="160" viewBox="0 0 160 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="outerRing" x1="20" y1="18" x2="140" y2="142" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0C5440" />
+      <stop offset="0.5" stop-color="#2FA37C" />
+      <stop offset="1" stop-color="#F0A233" />
+    </linearGradient>
+    <linearGradient id="orbit" x1="16" y1="28" x2="148" y2="124" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#1E7B5E" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#C88437" stop-opacity="0.9" />
+    </linearGradient>
+    <radialGradient id="core" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(80 80) scale(36)">
+      <stop offset="0" stop-color="#F7F5EE" />
+      <stop offset="1" stop-color="#E7C67C" />
+    </radialGradient>
+  </defs>
+
+  <circle cx="80" cy="80" r="74" stroke="url(#outerRing)" stroke-width="4.5" fill="none" />
+
+  <path
+    d="M36 56C48 38 66.5 28 80.5 28C104 28 124 52 124 80C124 108 104.5 132 80 132C63 132 45 120 34 100"
+    stroke="url(#orbit)"
+    stroke-width="4"
+    stroke-linecap="round"
+    fill="none"
+  />
+  <path
+    d="M124 64C112 40 92 26 74 26C50 26 32 50 32 80C32 108 50 134 74 134C94 134 114 122 126 100"
+    stroke="url(#orbit)"
+    stroke-width="4"
+    stroke-linecap="round"
+    fill="none"
+    opacity="0.75"
+  />
+
+  <circle cx="80" cy="80" r="32" fill="url(#core)" stroke="#1E7B5E" stroke-width="1.5" />
+
+  <g transform="translate(80 80)">
+    <path
+      d="M0 -18L5.5 -5.5L18 0L5.5 5.5L0 18L-5.5 5.5L-18 0L-5.5 -5.5Z"
+      fill="#1E7B5E"
+      opacity="0.18"
+    />
+    <path d="M0 -14L4.5 -4.5L14 0L4.5 4.5L0 14L-4.5 4.5L-14 0L-4.5 -4.5Z" fill="#2E8867" opacity="0.28" />
+    <path d="M0 -10L3 -3L10 0L3 3L0 10L-3 3L-10 0L-3 -3Z" fill="#155B43" opacity="0.4" />
+    <circle cx="0" cy="0" r="5.5" fill="#0F3F33" />
+  </g>
+</svg>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -46,7 +46,9 @@ const Features = () => {
         <div className="mx-auto max-w-3xl text-center">
           <p className="section-eyebrow">Creator Economy 2025</p>
           <h2 className="section-heading">
-            {isEnglish ? "Fortune 500 confidence. Bengali soul." : "ফর্চুন ৫০০ মানের নিশ্চয়তা। বাঙালি আবেগের সুর।"}
+            {isEnglish
+              ? "Enterprise-grade trust. Bengali brilliance."
+              : "এন্টারপ্রাইজ মানের আস্থা। বাঙালি মেধার দীপ্তি।"}
           </h2>
           <p className="section-subheading mx-auto mt-6">
             {isEnglish

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -6,65 +6,66 @@ const FinalCTA = () => {
   return (
     <section id="cta" className="py-20">
       <div className="mx-auto max-w-6xl px-4 md:px-8">
-        <div className="relative overflow-hidden rounded-[2.5rem] border border-white/60 bg-[var(--gradient-midnight)] px-8 py-12 text-white shadow-[var(--shadow-elevated)] md:px-16 md:py-16">
-          <div className="absolute -right-24 top-[-6rem] h-72 w-72 rounded-full bg-secondary/40 blur-3xl" />
-          <div className="absolute -left-24 bottom-[-8rem] h-72 w-72 rounded-full bg-primary/40 blur-3xl" />
+        <div className="relative overflow-hidden rounded-[2.5rem] border border-emerald-100 bg-gradient-to-r from-emerald-50 via-white to-amber-50 px-8 py-12 text-foreground shadow-[var(--shadow-elevated)] md:px-16 md:py-16">
+          <div className="absolute -right-24 top-[-6rem] h-72 w-72 rounded-full bg-sungold-200/55 blur-3xl" />
+          <div className="absolute -left-24 bottom-[-8rem] h-72 w-72 rounded-full bg-emerald-200/50 blur-3xl" />
+          <div className="absolute inset-0 bg-gradient-to-br from-white/70 via-transparent to-emerald-100/35" />
 
           <div className="relative grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
             <div className="space-y-4">
-              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-white/70">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-700">
                 {isEnglish ? "Start today" : "এখনই শুরু করুন"}
               </p>
-              <h2 className="text-3xl font-semibold md:text-4xl lg:text-5xl">
+              <h2 className="text-3xl font-semibold text-foreground md:text-4xl lg:text-5xl">
                 {isEnglish ? "Shape the future of AI creation." : "এআই সৃজনশীলতার ভবিষ্যৎ গড়ুন।"}
               </h2>
-              <p className="text-sm leading-relaxed text-white/80 md:text-base">
+              <p className="text-sm leading-relaxed text-muted-foreground md:text-base">
                 {isEnglish
                   ? "Join the Bengali-first prompt commerce network built for modern creators and enterprise buyers. We streamline monetisation, licensing, and compliance so you can focus on crafting high-impact prompts."
                   : "আধুনিক নির্মাতা ও এন্টারপ্রাইজ ক্রেতাদের জন্য নির্মিত বাঙালি প্রম্পট কমার্স নেটওয়ার্কে যোগ দিন। আয়, লাইসেন্সিং ও কমপ্লায়েন্স আমরা সামলাই—আপনি উচ্চমানের প্রম্পট নির্মাণে মন দিন।"}
               </p>
             </div>
 
-            <div className="space-y-4 rounded-3xl border border-white/40 bg-white/10 p-6 backdrop-blur">
-              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-white/70">
+            <div className="space-y-5 rounded-3xl border border-emerald-100 bg-white/90 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
+              <p className="text-sm font-semibold uppercase tracking-[0.3em] text-emerald-700">
                 {isEnglish ? "Choose your path" : "আপনার পথ বেছে নিন"}
               </p>
-              <div className="grid gap-3 text-sm font-semibold">
+              <div className="grid gap-3 text-sm font-semibold text-foreground">
                 <a
                   href="/community/submit"
-                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                  className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Creator onboarding" : "ক্রিয়েটর অনবোর্ডিং"}</span>
-                  <span aria-hidden>→</span>
+                  <span aria-hidden className="text-emerald-700">→</span>
                 </a>
                 <a
                   href="#enterprise"
-                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                  className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Enterprise discovery" : "এন্টারপ্রাইজ ডিসকভারি"}</span>
-                  <span aria-hidden>→</span>
+                  <span aria-hidden className="text-emerald-700">→</span>
                 </a>
                 <a
                   href="#insights"
-                  className="flex items-center justify-between rounded-2xl border border-white/60 bg-white/20 px-4 py-3 transition-all hover:bg-white/30"
+                  className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Download insights" : "ইনসাইটস ডাউনলোড"}</span>
-                  <span aria-hidden>→</span>
+                  <span aria-hidden className="text-emerald-700">→</span>
                 </a>
               </div>
 
-              <div className="rounded-2xl border border-white/40 bg-white/20 p-4 text-sm text-white/80">
-                <p className="font-semibold uppercase tracking-[0.2em]">
+              <div className="rounded-2xl border border-emerald-100 bg-emerald-50/90 p-4 text-sm text-muted-foreground">
+                <p className="font-semibold uppercase tracking-[0.2em] text-emerald-700">
                   {isEnglish ? "72h Creator Care" : "৭২ ঘণ্টার ক্রিয়েটর কেয়ার"}
                 </p>
-                <p className="mt-1">
+                <p className="mt-1 text-foreground">
                   {isEnglish
                     ? "Dedicated bilingual concierge ensures every creator or enterprise request is resolved within three days."
                     : "প্রতিটি ক্রিয়েটর বা এন্টারপ্রাইজ অনুরোধ ৩ দিনের মধ্যে সমাধান নিশ্চিত করতে ডেডিকেটেড কনসিয়ার্জ।"}
                 </p>
               </div>
 
-              <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-white/70">
+              <div className="flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.3em] text-muted-foreground">
                 <span>Dhaka</span>
                 <span>•</span>
                 <span>Singapore</span>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -49,11 +49,13 @@ const Footer = () => {
         <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr]">
           <div className="space-y-6">
             <div className="flex items-center gap-3">
-              <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--gradient-aurora)] text-white">
-                <span className="text-lg font-semibold">BP</span>
-              </div>
+              <img
+                src="/promptbazar-logo.svg"
+                alt="PromptBazar.AI logo"
+                className="h-12 w-12 rounded-xl border border-white/20 bg-white/90 p-1.5 shadow-[var(--shadow-soft)]"
+              />
               <div>
-                <p className="text-base font-semibold">BanglaPrompt.ai</p>
+                <p className="text-base font-semibold">PromptBazar.AI</p>
                 <p className="text-xs uppercase tracking-[0.3em] text-white/70">
                   {isEnglish
                     ? "Bangladesh’s first prompt marketplace • Global reach"
@@ -64,7 +66,7 @@ const Footer = () => {
             <p className="text-sm leading-relaxed text-white/70 md:text-base">
               {isEnglish
                 ? "A global AI prompt marketplace connecting Bengali prompt creators with international buyers through bilingual storefronts, transparent revenue operations, and compliance-ready tooling."
-                : "দ্বিভাষিক স্টোরফ্রন্ট, স্বচ্ছ আয় ব্যবস্থাপনা ও কমপ্লায়েন্স-প্রস্তুত টুলিংয়ের মাধ্যমে বাংলা প্রম্পট নির্মাতাদেরকে আন্তর্জাতিক ক্রেতাদের সাথে যুক্ত করে BanglaPrompt.ai।"}
+                : "দ্বিভাষিক স্টোরফ্রন্ট, স্বচ্ছ আয় ব্যবস্থাপনা ও কমপ্লায়েন্স-প্রস্তুত টুলিংয়ের মাধ্যমে বাংলা প্রম্পট নির্মাতাদেরকে আন্তর্জাতিক ক্রেতাদের সাথে যুক্ত করে PromptBazar.AI।"}
             </p>
           </div>
 
@@ -130,7 +132,7 @@ const Footer = () => {
         </div>
 
         <div className="mt-16 flex flex-col gap-4 border-t border-white/10 pt-6 text-xs text-white/60 md:flex-row md:items-center md:justify-between">
-          <p>© {currentYear} BanglaPrompt.ai. {isEnglish ? "All rights reserved." : "সমস্ত স্বত্ব সংরক্ষিত।"}</p>
+          <p>© {currentYear} PromptBazar.AI. {isEnglish ? "All rights reserved." : "সমস্ত স্বত্ব সংরক্ষিত।"}</p>
           <p>{isEnglish ? "Built with Bengali creativity for global teams." : "বাংলা সৃজনশীলতায় নির্মিত—গ্লোবাল টিমের জন্য।"}</p>
         </div>
       </div>

--- a/src/components/GlobalCommunity.tsx
+++ b/src/components/GlobalCommunity.tsx
@@ -105,8 +105,8 @@ const GlobalCommunity = () => {
             </div>
             <p className="mt-2 text-sm text-muted-foreground">
               {isEnglish
-                ? "Explore how BanglaPrompt.ai is embedded across creative, operational, and compliance teams."
-                : "ক্রিয়েটিভ, অপারেশনাল ও কমপ্লায়েন্স টিমে BanglaPrompt.ai কীভাবে প্রয়োগ হচ্ছে তা জানুন।"}
+                ? "Explore how PromptBazar.AI is embedded across creative, operational, and compliance teams."
+                : "ক্রিয়েটিভ, অপারেশনাল ও কমপ্লায়েন্স টিমে PromptBazar.AI কীভাবে প্রয়োগ হচ্ছে তা জানুন।"}
             </p>
 
             <div className="mt-6 grid gap-4">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -64,13 +64,15 @@ const Navbar = () => {
     >
       <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 md:px-8">
         <a href="#top" className="flex items-center gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-[var(--gradient-aurora)] text-white shadow-[var(--shadow-soft)]">
-            <span className="text-lg font-semibold">BP</span>
-          </div>
+          <img
+            src="/promptbazar-logo.svg"
+            alt="PromptBazar.AI logo"
+            className="h-11 w-11 rounded-xl border border-emerald-100 bg-white p-1.5 shadow-[var(--shadow-soft)]"
+          />
           <div className="hidden text-left md:block">
-            <span className="text-sm font-semibold text-foreground md:text-base">BanglaPrompt.ai</span>
+            <span className="text-sm font-semibold text-foreground md:text-base">PromptBazar.AI</span>
             <span className="block text-xs font-medium uppercase tracking-[0.24em] text-muted-foreground/80">
-              Global Prompt Marketplace
+              Bengali Prompt Marketplace
             </span>
           </div>
         </a>

--- a/src/components/SEOHead.tsx
+++ b/src/components/SEOHead.tsx
@@ -10,10 +10,10 @@ interface SEOHeadProps {
 }
 
 const SEOHead: React.FC<SEOHeadProps> = ({
-  title = "BanglaPrompt.ai – Bangladesh’s first global AI prompt marketplace",
+  title = "PromptBazar.AI – Bangladesh’s first global AI prompt marketplace",
   description =
     "Launch bilingual prompt storefronts, sell culturally rich AI workflows, and reach verified global buyers with transparent revenue tools and enterprise compliance.",
-  keywords = "BanglaPrompt.ai, Bengali AI prompts, sell prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation",
+  keywords = "PromptBazar.AI, BanglaPrompt.ai, Bengali AI prompts, sell prompts, global prompt marketplace, creator economy Bangladesh, enterprise AI localisation",
   image = "/og-image.png",
   url = "https://banglaprompt.ai/"
 }) => {


### PR DESCRIPTION
## Summary
- swap the site branding to PromptBazar.AI across metadata, navigation, footer, and structured data
- add a reusable PromptBazar.AI logo asset and surface it in the header and footer
- brighten the closing CTA section and adjust the features headline copy for clearer, on-brand messaging

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd8dbe1b408326a49dbd2d8c0db7a1