### PR TITLE
Connect pricing transparency section to Supabase-managed content

### DIFF
--- a/src/components/PricingTransparency.tsx
+++ b/src/components/PricingTransparency.tsx
@@ -1,80 +1,207 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Coins, LineChart, ShieldCheck } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { useLanguage } from "@/contexts/LanguageContext";
+import { fetchPricingContent, type PricingContent } from "@/utils/pricing/api";
 
-type Audience = "creators" | "enterprise";
+const FALLBACK_TIMESTAMP = "1970-01-01T00:00:00Z";
 
-const tiers: Record<Audience, {
-  headlineEn: string;
-  headlineBn: string;
-  price: string;
-  priceBn: string;
-  descriptionEn: string;
-  descriptionBn: string;
-  features: string[];
-  featuresBn: string[];
-  cta: string;
-  ctaBn: string;
-}> = {
-  creators: {
-    headlineEn: "Creator revenue share",
-    headlineBn: "ক্রিয়েটর রেভিনিউ শেয়ার",
-    price: "Keep up to 80%",
-    priceBn: "৮০% পর্যন্ত আপনার",
-    descriptionEn:
-      "No listing fees. Automated royalty forecasts. Instant dashboards for payouts across USD, BDT, EUR, SAR.",
-    descriptionBn:
-      "লিস্টিং ফি নেই। স্বয়ংক্রিয় রয়্যালটি পূর্বাভাস। USD, BDT, EUR, SAR এ তাৎক্ষণিক পেআউট ড্যাশবোর্ড।",
-    features: [
-      "Dynamic pricing guidance", "72-hour payout commitment", "Collaboration rooms with legal templates",
-    ],
-    featuresBn: [
-      "ডায়নামিক প্রাইসিং নির্দেশিকা", "৭২ ঘণ্টায় পেমেন্ট নিশ্চিত", "লিগ্যাল টেমপ্লেটসহ সহযোগিতা স্পেস",
-    ],
-    cta: "Join as creator",
-    ctaBn: "ক্রিয়েটর হিসেবে যোগ দিন",
-  },
-  enterprise: {
-    headlineEn: "Enterprise localisation suite",
-    headlineBn: "এন্টারপ্রাইজ লোকালাইজেশন স্যুইট",
-    price: "Custom annual partnership",
-    priceBn: "কাস্টম বার্ষিক পার্টনারশিপ",
-    descriptionEn:
-      "Dedicated curator pods, compliance vaults, and co-marketing launches across 70+ countries.",
-    descriptionBn:
-      "ডেডিকেটেড কিউরেটর টিম, কমপ্লায়েন্স ভল্ট ও ৭০+ দেশে কো-মার্কেটিং লঞ্চ।",
-    features: [
-      "Global prompt orchestration", "Governance workshops", "Executive analytics briefings",
-    ],
-    featuresBn: [
-      "গ্লোবাল প্রম্পট অর্কেস্ট্রেশন", "গভর্নেন্স ওয়ার্কশপ", "এক্সিকিউটিভ অ্যানালিটিক্স ব্রিফিং",
-    ],
-    cta: "Book enterprise session",
-    ctaBn: "এন্টারপ্রাইজ সেশন বুক করুন",
-  },
+const fallbackContent: PricingContent = {
+  audiences: [
+    {
+      id: "fallback-creators",
+      slug: "creators",
+      headline_en: "Creator revenue share",
+      headline_bn: "ক্রিয়েটর রেভিনিউ শেয়ার",
+      toggle_label_en: "Creators",
+      toggle_label_bn: "ক্রিয়েটরস",
+      price_text_en: "Keep up to 80%",
+      price_text_bn: "৮০% পর্যন্ত আপনার",
+      description_en:
+        "No listing fees. Automated royalty forecasts. Instant dashboards for payouts across USD, BDT, EUR, SAR.",
+      description_bn:
+        "লিস্টিং ফি নেই। স্বয়ংক্রিয় রয়্যালটি পূর্বাভাস। USD, BDT, EUR, SAR এ তাৎক্ষণিক পেআউট ড্যাশবোর্ড।",
+      cta_label_en: "Join as creator",
+      cta_label_bn: "ক্রিয়েটর হিসেবে যোগ দিন",
+      cta_link: "/community/submit",
+      sort_order: 1,
+      is_active: true,
+      created_at: FALLBACK_TIMESTAMP,
+      updated_at: FALLBACK_TIMESTAMP,
+      features: [
+        {
+          id: "fallback-creators-feature-1",
+          audience_id: "fallback-creators",
+          feature_en: "Dynamic pricing guidance",
+          feature_bn: "ডায়নামিক প্রাইসিং নির্দেশিকা",
+          sort_order: 1,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+        {
+          id: "fallback-creators-feature-2",
+          audience_id: "fallback-creators",
+          feature_en: "72-hour payout commitment",
+          feature_bn: "৭২ ঘণ্টায় পেমেন্ট নিশ্চিত",
+          sort_order: 2,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+        {
+          id: "fallback-creators-feature-3",
+          audience_id: "fallback-creators",
+          feature_en: "Collaboration rooms with legal templates",
+          feature_bn: "লিগ্যাল টেমপ্লেটসহ সহযোগিতা স্পেস",
+          sort_order: 3,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+      ],
+    },
+    {
+      id: "fallback-enterprise",
+      slug: "enterprise",
+      headline_en: "Enterprise localisation suite",
+      headline_bn: "এন্টারপ্রাইজ লোকালাইজেশন স্যুইট",
+      toggle_label_en: "Enterprise",
+      toggle_label_bn: "এন্টারপ্রাইজ",
+      price_text_en: "Custom annual partnership",
+      price_text_bn: "কাস্টম বার্ষিক পার্টনারশিপ",
+      description_en:
+        "Dedicated curator pods, compliance vaults, and co-marketing launches across 70+ countries.",
+      description_bn: "ডেডিকেটেড কিউরেটর টিম, কমপ্লায়েন্স ভল্ট ও ৭০+ দেশে কো-মার্কেটিং লঞ্চ।",
+      cta_label_en: "Book enterprise session",
+      cta_label_bn: "এন্টারপ্রাইজ সেশন বুক করুন",
+      cta_link: "#enterprise",
+      sort_order: 2,
+      is_active: true,
+      created_at: FALLBACK_TIMESTAMP,
+      updated_at: FALLBACK_TIMESTAMP,
+      features: [
+        {
+          id: "fallback-enterprise-feature-1",
+          audience_id: "fallback-enterprise",
+          feature_en: "Global prompt orchestration",
+          feature_bn: "গ্লোবাল প্রম্পট অর্কেস্ট্রেশন",
+          sort_order: 1,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+        {
+          id: "fallback-enterprise-feature-2",
+          audience_id: "fallback-enterprise",
+          feature_en: "Governance workshops",
+          feature_bn: "গভর্নেন্স ওয়ার্কশপ",
+          sort_order: 2,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+        {
+          id: "fallback-enterprise-feature-3",
+          audience_id: "fallback-enterprise",
+          feature_en: "Executive analytics briefings",
+          feature_bn: "এক্সিকিউটিভ অ্যানালিটিক্স ব্রিফিং",
+          sort_order: 3,
+          is_active: true,
+          created_at: FALLBACK_TIMESTAMP,
+          updated_at: FALLBACK_TIMESTAMP,
+        },
+      ],
+    },
+  ],
+  highlights: [
+    {
+      id: "fallback-highlight-1",
+      icon_key: "line-chart",
+      title_en: "Predictive royalty modeling",
+      title_bn: "প্রেডিক্টিভ রয়্যালটি মডেলিং",
+      description_en:
+        "See future payout trends before you launch. Toggle between USD, BDT, EUR, and SAR projections in a single pane.",
+      description_bn:
+        "লঞ্চের আগেই পেআউট ট্রেন্ড দেখে নিন। USD, BDT, EUR ও SAR পূর্বাভাস একসাথে পর্যবেক্ষণ করুন।",
+      sort_order: 1,
+      is_active: true,
+      created_at: FALLBACK_TIMESTAMP,
+      updated_at: FALLBACK_TIMESTAMP,
+    },
+    {
+      id: "fallback-highlight-2",
+      icon_key: "shield-check",
+      title_en: "Fairness charter",
+      title_bn: "ফেয়ারনেস চার্টার",
+      description_en:
+        "Transparent dispute resolution, co-creation credits, and legal-safe collaboration agreements.",
+      description_bn: "স্বচ্ছ বিরোধ নিষ্পত্তি, কো-ক্রিয়েশন ক্রেডিট এবং আইন-সম্মত সহযোগিতা চুক্তি।",
+      sort_order: 2,
+      is_active: true,
+      created_at: FALLBACK_TIMESTAMP,
+      updated_at: FALLBACK_TIMESTAMP,
+    },
+  ],
+};
+
+const highlightIcons = {
+  "line-chart": LineChart,
+  "shield-check": ShieldCheck,
+  coins: Coins,
 };
 
 const PricingTransparency = () => {
   const { language } = useLanguage();
   const isEnglish = language === "en";
-  const [audience, setAudience] = useState<Audience>("creators");
-  const tier = tiers[audience];
-  const tierHeadline = isEnglish ? tier.headlineEn : tier.headlineBn;
-  const tierPrice = isEnglish ? tier.price : tier.priceBn;
-  const tierDescription = isEnglish ? tier.descriptionEn : tier.descriptionBn;
-  const tierFeatures = isEnglish ? tier.features : tier.featuresBn;
-  const tierCta = isEnglish ? tier.cta : tier.ctaBn;
+  const [selectedAudienceSlug, setSelectedAudienceSlug] = useState<string>(fallbackContent.audiences[0].slug);
 
+  const { data: pricingContent, isError } = useQuery({
+    queryKey: ["pricing-transparency"],
+    queryFn: fetchPricingContent,
+  });
+
+  useEffect(() => {
+    if (isError) {
+      console.error("Failed to load pricing transparency content from Supabase");
+    }
+  }, [isError]);
+
+  const audiences = useMemo(
+    () => (pricingContent?.audiences?.length ? pricingContent.audiences : fallbackContent.audiences),
+    [pricingContent?.audiences],
+  );
+
+  const highlights = useMemo(
+    () => (pricingContent?.highlights?.length ? pricingContent.highlights : fallbackContent.highlights),
+    [pricingContent?.highlights],
+  );
+
+  useEffect(() => {
+    if (audiences.length > 0 && !audiences.some(audience => audience.slug === selectedAudienceSlug)) {
+      setSelectedAudienceSlug(audiences[0].slug);
+    }
+  }, [audiences, selectedAudienceSlug]);
+
+  const activeAudience = audiences.find(audience => audience.slug === selectedAudienceSlug) ?? audiences[0];
+  const tierHeadline = isEnglish ? activeAudience.headline_en : activeAudience.headline_bn;
+  const tierPrice = isEnglish ? activeAudience.price_text_en : activeAudience.price_text_bn;
+  const tierDescription = isEnglish ? activeAudience.description_en : activeAudience.description_bn;
+  const tierFeatures = activeAudience.features.map(feature => ({
+    id: feature.id,
+    text: isEnglish ? feature.feature_en : feature.feature_bn,
+  }));
+  const tierCtaLabel = isEnglish ? activeAudience.cta_label_en : activeAudience.cta_label_bn;
 
   return (
     <section id="pricing" className="section bg-gradient-to-b from-primary/5 via-transparent to-background">
       <div className="mx-auto max-w-7xl px-4 md:px-8">
         <div className="text-center">
-          <p className="section-eyebrow">{isEnglish ? "Pricing & Revenue Transparency" : "প্রাইসিং ও রেভিনিউ স্বচ্ছতা"}</p>
+          <p className="section-eyebrow">
+            {isEnglish ? "Pricing & Revenue Transparency" : "প্রাইসিং ও রেভিনিউ স্বচ্ছতা"}
+          </p>
           <h2 className="section-heading">
-            {isEnglish
-              ? "Predictable economics for every collaborator."
-              : "প্রত্যেক অংশীদারের জন্য পূর্বানুমানযোগ্য অর্থনীতি।"}
+            {isEnglish ? "Predictable economics for every collaborator." : "প্রত্যেক অংশীদারের জন্য পূর্বানুমানযোগ্য অর্থনীতি।"}
           </h2>
           <p className="section-subheading mx-auto mt-6">
             {isEnglish
@@ -83,29 +210,21 @@ const PricingTransparency = () => {
           </p>
         </div>
 
-        <div className="mt-12 flex justify-center gap-4">
-          <button
-            type="button"
-            onClick={() => setAudience("creators")}
-            className={`rounded-full px-5 py-2 text-sm font-semibold transition-all ${
-              audience === "creators"
-                ? "bg-primary text-white shadow-[var(--shadow-soft)]"
-                : "bg-white text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            {isEnglish ? "Creators" : "ক্রিয়েটরস"}
-          </button>
-          <button
-            type="button"
-            onClick={() => setAudience("enterprise")}
-            className={`rounded-full px-5 py-2 text-sm font-semibold transition-all ${
-              audience === "enterprise"
-                ? "bg-primary text-white shadow-[var(--shadow-soft)]"
-                : "bg-white text-muted-foreground hover:text-foreground"
-            }`}
-          >
-            {isEnglish ? "Enterprise" : "এন্টারপ্রাইজ"}
-          </button>
+        <div className="mt-12 flex flex-wrap justify-center gap-4">
+          {audiences.map(audience => (
+            <button
+              key={audience.id}
+              type="button"
+              onClick={() => setSelectedAudienceSlug(audience.slug)}
+              className={`rounded-full px-5 py-2 text-sm font-semibold transition-all ${
+                audience.slug === selectedAudienceSlug
+                  ? "bg-primary text-white shadow-[var(--shadow-soft)]"
+                  : "bg-white text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {isEnglish ? audience.toggle_label_en : audience.toggle_label_bn}
+            </button>
+          ))}
         </div>
 
         <div className="mt-12 grid gap-10 lg:grid-cols-[1.1fr_0.9fr]">
@@ -124,53 +243,46 @@ const PricingTransparency = () => {
             <p className="mt-6 text-sm leading-relaxed text-muted-foreground">{tierDescription}</p>
 
             <div className="mt-8 grid gap-3 text-sm text-muted-foreground">
-              {tierFeatures.map((feature) => (
-                <div key={feature} className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4">
-                  <p className="text-foreground">{feature}</p>
+              {tierFeatures.map(feature => (
+                <div
+                  key={feature.id}
+                  className="rounded-2xl border border-muted-foreground/20 bg-background/80 p-4"
+                >
+                  <p className="text-foreground">{feature.text}</p>
                 </div>
               ))}
             </div>
 
             <a
-              href={audience === "creators" ? "/community/submit" : "#enterprise"}
+              href={activeAudience.cta_link}
               className="mt-8 inline-flex items-center justify-center rounded-full bg-[var(--gradient-aurora)] px-6 py-3 text-sm font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
             >
-              {tierCta}
+              {tierCtaLabel}
             </a>
           </div>
 
           <div className="space-y-6">
-            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
-              <div className="flex items-center gap-3">
-                <LineChart className="h-6 w-6 text-secondary" />
-                <div>
-                  <p className="text-sm font-semibold text-foreground">
-                    {isEnglish ? "Predictive royalty modeling" : "প্রেডিক্টিভ রয়্যালটি মডেলিং"}
+            {highlights.map(highlight => {
+              const Icon = highlightIcons[highlight.icon_key as keyof typeof highlightIcons] ?? ShieldCheck;
+              return (
+                <div
+                  key={highlight.id}
+                  className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur"
+                >
+                  <div className="flex items-center gap-3">
+                    <Icon className="h-6 w-6 text-secondary" />
+                    <div>
+                      <p className="text-sm font-semibold text-foreground">
+                        {isEnglish ? highlight.title_en : highlight.title_bn}
+                      </p>
+                    </div>
+                  </div>
+                  <p className="mt-3 text-sm text-muted-foreground">
+                    {isEnglish ? highlight.description_en : highlight.description_bn}
                   </p>
                 </div>
-              </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                {isEnglish
-                  ? "See future payout trends before you launch. Toggle between USD, BDT, EUR, and SAR projections in a single pane."
-                  : "লঞ্চের আগেই পেআউট ট্রেন্ড দেখে নিন। USD, BDT, EUR ও SAR পূর্বাভাস একসাথে পর্যবেক্ষণ করুন।"}
-              </p>
-            </div>
-
-            <div className="rounded-[2rem] border border-white/60 bg-white/80 p-6 shadow-[var(--shadow-soft)] backdrop-blur">
-              <div className="flex items-center gap-3">
-                <ShieldCheck className="h-6 w-6 text-primary" />
-                <div>
-                  <p className="text-sm font-semibold text-foreground">
-                    {isEnglish ? "Fairness charter" : "ফেয়ারনেস চার্টার"}
-                  </p>
-                </div>
-              </div>
-              <p className="mt-3 text-sm text-muted-foreground">
-                {isEnglish
-                  ? "Transparent dispute resolution, co-creation credits, and legal-safe collaboration agreements."
-                  : "স্বচ্ছ বিরোধ নিষ্পত্তি, কো-ক্রিয়েশন ক্রেডিট এবং আইন-সম্মত সহযোগিতা চুক্তি।"}
-              </p>
-            </div>
+              );
+            })}
           </div>
         </div>
       </div>

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -118,6 +118,146 @@ export type Database = {
           }
         ]
       }
+      pricing_audiences: {
+        Row: {
+          cta_label_bn: string
+          cta_label_en: string
+          cta_link: string
+          description_bn: string
+          description_en: string
+          headline_bn: string
+          headline_en: string
+          id: string
+          is_active: boolean
+          price_text_bn: string
+          price_text_en: string
+          slug: string
+          sort_order: number
+          toggle_label_bn: string
+          toggle_label_en: string
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          cta_label_bn: string
+          cta_label_en: string
+          cta_link: string
+          description_bn: string
+          description_en: string
+          headline_bn: string
+          headline_en: string
+          id?: string
+          is_active?: boolean
+          price_text_bn: string
+          price_text_en: string
+          slug: string
+          sort_order?: number
+          toggle_label_bn: string
+          toggle_label_en: string
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          cta_label_bn?: string
+          cta_label_en?: string
+          cta_link?: string
+          description_bn?: string
+          description_en?: string
+          headline_bn?: string
+          headline_en?: string
+          id?: string
+          is_active?: boolean
+          price_text_bn?: string
+          price_text_en?: string
+          slug?: string
+          sort_order?: number
+          toggle_label_bn?: string
+          toggle_label_en?: string
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
+      pricing_features: {
+        Row: {
+          audience_id: string
+          created_at: string
+          feature_bn: string
+          feature_en: string
+          id: string
+          is_active: boolean
+          sort_order: number
+          updated_at: string
+        }
+        Insert: {
+          audience_id: string
+          created_at?: string
+          feature_bn: string
+          feature_en: string
+          id?: string
+          is_active?: boolean
+          sort_order?: number
+          updated_at?: string
+        }
+        Update: {
+          audience_id?: string
+          created_at?: string
+          feature_bn?: string
+          feature_en?: string
+          id?: string
+          is_active?: boolean
+          sort_order?: number
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "pricing_features_audience_id_fkey"
+            columns: ["audience_id"]
+            isOneToOne: false
+            referencedRelation: "pricing_audiences"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      pricing_highlights: {
+        Row: {
+          created_at: string
+          description_bn: string
+          description_en: string
+          icon_key: string
+          id: string
+          is_active: boolean
+          sort_order: number
+          title_bn: string
+          title_en: string
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          description_bn: string
+          description_en: string
+          icon_key: string
+          id?: string
+          is_active?: boolean
+          sort_order?: number
+          title_bn: string
+          title_en: string
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          description_bn?: string
+          description_en?: string
+          icon_key?: string
+          id?: string
+          is_active?: boolean
+          sort_order?: number
+          title_bn?: string
+          title_en?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       tool_subscriptions: {
         Row: {
           buyer_id: string

--- a/src/utils/pricing/api.ts
+++ b/src/utils/pricing/api.ts
@@ -1,0 +1,61 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { Tables } from "@/integrations/supabase/types";
+
+type PricingAudienceRow = Tables<"pricing_audiences">;
+type PricingFeatureRow = Tables<"pricing_features">;
+type PricingHighlightRow = Tables<"pricing_highlights">;
+
+export type PricingAudienceWithFeatures = PricingAudienceRow & {
+  features: PricingFeatureRow[];
+};
+
+export type PricingContent = {
+  audiences: PricingAudienceWithFeatures[];
+  highlights: PricingHighlightRow[];
+};
+
+const sortByOrder = <T extends { sort_order: number }>(items: T[]) =>
+  [...items].sort((a, b) => a.sort_order - b.sort_order);
+
+export const fetchPricingContent = async (): Promise<PricingContent> => {
+  const [audiencesResult, featuresResult, highlightsResult] = await Promise.all([
+    supabase
+      .from("pricing_audiences")
+      .select("*")
+      .eq("is_active", true)
+      .order("sort_order", { ascending: true }),
+    supabase
+      .from("pricing_features")
+      .select("*")
+      .eq("is_active", true),
+    supabase
+      .from("pricing_highlights")
+      .select("*")
+      .eq("is_active", true)
+      .order("sort_order", { ascending: true }),
+  ]);
+
+  if (audiencesResult.error) {
+    throw audiencesResult.error;
+  }
+
+  if (featuresResult.error) {
+    throw featuresResult.error;
+  }
+
+  if (highlightsResult.error) {
+    throw highlightsResult.error;
+  }
+
+  const audiences = (audiencesResult.data ?? []).map<PricingAudienceWithFeatures>(audience => ({
+    ...audience,
+    features: sortByOrder(
+      (featuresResult.data ?? []).filter(feature => feature.audience_id === audience.id),
+    ),
+  }));
+
+  return {
+    audiences,
+    highlights: sortByOrder(highlightsResult.data ?? []),
+  };
+};

--- a/supabase/migrations/20250721090000-pricing-transparency.sql
+++ b/supabase/migrations/20250721090000-pricing-transparency.sql
@@ -1,0 +1,210 @@
+-- Pricing transparency content stored in Supabase for dynamic management
+CREATE TABLE public.pricing_audiences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  slug TEXT UNIQUE NOT NULL,
+  headline_en TEXT NOT NULL,
+  headline_bn TEXT NOT NULL,
+  toggle_label_en TEXT NOT NULL,
+  toggle_label_bn TEXT NOT NULL,
+  price_text_en TEXT NOT NULL,
+  price_text_bn TEXT NOT NULL,
+  description_en TEXT NOT NULL,
+  description_bn TEXT NOT NULL,
+  cta_label_en TEXT NOT NULL,
+  cta_label_bn TEXT NOT NULL,
+  cta_link TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER pricing_audiences_set_updated_at
+BEFORE UPDATE ON public.pricing_audiences
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.pricing_audiences ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Pricing audiences readable by everyone"
+  ON public.pricing_audiences
+  FOR SELECT
+  USING (is_active);
+
+CREATE POLICY "Service role manages pricing audiences"
+  ON public.pricing_audiences
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE TABLE public.pricing_features (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  audience_id UUID NOT NULL REFERENCES public.pricing_audiences(id) ON DELETE CASCADE,
+  feature_en TEXT NOT NULL,
+  feature_bn TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_pricing_features_audience_sort
+  ON public.pricing_features (audience_id, sort_order);
+
+CREATE TRIGGER pricing_features_set_updated_at
+BEFORE UPDATE ON public.pricing_features
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.pricing_features ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Pricing features readable by everyone"
+  ON public.pricing_features
+  FOR SELECT
+  USING (is_active);
+
+CREATE POLICY "Service role manages pricing features"
+  ON public.pricing_features
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+CREATE TABLE public.pricing_highlights (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  icon_key TEXT NOT NULL,
+  title_en TEXT NOT NULL,
+  title_bn TEXT NOT NULL,
+  description_en TEXT NOT NULL,
+  description_bn TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER pricing_highlights_set_updated_at
+BEFORE UPDATE ON public.pricing_highlights
+FOR EACH ROW
+EXECUTE FUNCTION public.set_updated_at();
+
+ALTER TABLE public.pricing_highlights ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Pricing highlights readable by everyone"
+  ON public.pricing_highlights
+  FOR SELECT
+  USING (is_active);
+
+CREATE POLICY "Service role manages pricing highlights"
+  ON public.pricing_highlights
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+-- Seed default content to match the launch experience
+WITH creators AS (
+  INSERT INTO public.pricing_audiences (
+    slug,
+    headline_en,
+    headline_bn,
+    toggle_label_en,
+    toggle_label_bn,
+    price_text_en,
+    price_text_bn,
+    description_en,
+    description_bn,
+    cta_label_en,
+    cta_label_bn,
+    cta_link,
+    sort_order
+  )
+  VALUES (
+    'creators',
+    'Creator revenue share',
+    'ক্রিয়েটর রেভিনিউ শেয়ার',
+    'Creators',
+    'ক্রিয়েটরস',
+    'Keep up to 80%',
+    '৮০% পর্যন্ত আপনার',
+    'No listing fees. Automated royalty forecasts. Instant dashboards for payouts across USD, BDT, EUR, SAR.',
+    'লিস্টিং ফি নেই। স্বয়ংক্রিয় রয়্যালটি পূর্বাভাস। USD, BDT, EUR, SAR এ তাৎক্ষণিক পেআউট ড্যাশবোর্ড।',
+    'Join as creator',
+    'ক্রিয়েটর হিসেবে যোগ দিন',
+    '/community/submit',
+    1
+  )
+  RETURNING id
+), enterprise AS (
+  INSERT INTO public.pricing_audiences (
+    slug,
+    headline_en,
+    headline_bn,
+    toggle_label_en,
+    toggle_label_bn,
+    price_text_en,
+    price_text_bn,
+    description_en,
+    description_bn,
+    cta_label_en,
+    cta_label_bn,
+    cta_link,
+    sort_order
+  )
+  VALUES (
+    'enterprise',
+    'Enterprise localisation suite',
+    'এন্টারপ্রাইজ লোকালাইজেশন স্যুইট',
+    'Enterprise',
+    'এন্টারপ্রাইজ',
+    'Custom annual partnership',
+    'কাস্টম বার্ষিক পার্টনারশিপ',
+    'Dedicated curator pods, compliance vaults, and co-marketing launches across 70+ countries.',
+    'ডেডিকেটেড কিউরেটর টিম, কমপ্লায়েন্স ভল্ট ও ৭০+ দেশে কো-মার্কেটিং লঞ্চ।',
+    'Book enterprise session',
+    'এন্টারপ্রাইজ সেশন বুক করুন',
+    '#enterprise',
+    2
+  )
+  RETURNING id
+)
+INSERT INTO public.pricing_features (audience_id, feature_en, feature_bn, sort_order)
+SELECT c.id, f.feature_en, f.feature_bn, f.sort_order
+FROM creators c
+CROSS JOIN (VALUES
+  ('Dynamic pricing guidance', 'ডায়নামিক প্রাইসিং নির্দেশিকা', 1),
+  ('72-hour payout commitment', '৭২ ঘণ্টায় পেমেন্ট নিশ্চিত', 2),
+  ('Collaboration rooms with legal templates', 'লিগ্যাল টেমপ্লেটসহ সহযোগিতা স্পেস', 3)
+) AS f(feature_en, feature_bn, sort_order)
+UNION ALL
+SELECT e.id, f.feature_en, f.feature_bn, f.sort_order
+FROM enterprise e
+CROSS JOIN (VALUES
+  ('Global prompt orchestration', 'গ্লোবাল প্রম্পট অর্কেস্ট্রেশন', 1),
+  ('Governance workshops', 'গভর্নেন্স ওয়ার্কশপ', 2),
+  ('Executive analytics briefings', 'এক্সিকিউটিভ অ্যানালিটিক্স ব্রিফিং', 3)
+) AS f(feature_en, feature_bn, sort_order);
+
+INSERT INTO public.pricing_highlights (
+  icon_key,
+  title_en,
+  title_bn,
+  description_en,
+  description_bn,
+  sort_order
+)
+VALUES
+  (
+    'line-chart',
+    'Predictive royalty modeling',
+    'প্রেডিক্টিভ রয়্যালটি মডেলিং',
+    'See future payout trends before you launch. Toggle between USD, BDT, EUR, and SAR projections in a single pane.',
+    'লঞ্চের আগেই পেআউট ট্রেন্ড দেখে নিন। USD, BDT, EUR ও SAR পূর্বাভাস একসাথে পর্যবেক্ষণ করুন।',
+    1
+  ),
+  (
+    'shield-check',
+    'Fairness charter',
+    'ফেয়ারনেস চার্টার',
+    'Transparent dispute resolution, co-creation credits, and legal-safe collaboration agreements.',
+    'স্বচ্ছ বিরোধ নিষ্পত্তি, কো-ক্রিয়েশন ক্রেডিট এবং আইন-সম্মত সহযোগিতা চুক্তি।',
+    2
+  );


### PR DESCRIPTION
## Summary
- add Supabase tables for pricing audiences, features, and highlights together with seed content
- expose a Supabase pricing content fetcher for the frontend
- render the pricing transparency section from Supabase data with graceful fallbacks

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cd9a484c688326ac80f47a6ee8a851