### PR TITLE
Refactor landing sections into dedicated routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,27 @@
 import React, { Suspense, useEffect } from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { HelmetProvider } from "react-helmet-async";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
-import { HelmetProvider } from "react-helmet-async";
 import { createScopedLogger } from "@/lib/logger";
 import EnvironmentDebug from "@/components/EnvironmentDebug";
+import { LanguageProvider } from "@/contexts/LanguageContext";
+import CookieConsent from "@/components/CookieConsent";
+import {
+  LazyMediumSubscriptionPopup,
+  LazyNewsletterConversionPopup,
+} from "@/components/LazyComponents";
 
 const Index = React.lazy(() => import("./pages/Index"));
+const Marketplace = React.lazy(() => import("./pages/Marketplace"));
+const Exchange = React.lazy(() => import("./pages/Exchange"));
+const Creators = React.lazy(() => import("./pages/Creators"));
+const Enterprise = React.lazy(() => import("./pages/Enterprise"));
+const Pricing = React.lazy(() => import("./pages/Pricing"));
+const Insights = React.lazy(() => import("./pages/Insights"));
+const Support = React.lazy(() => import("./pages/Support"));
 const NotFound = React.lazy(() => import("./pages/NotFound"));
 const PrivacyPolicy = React.lazy(() => import("./pages/PrivacyPolicy"));
 const CookiePolicy = React.lazy(() => import("./pages/CookiePolicy"));
@@ -54,33 +67,49 @@ const App = () => {
 
   return (
     <HelmetProvider>
-      <QueryClientProvider client={queryClient}>
-        <TooltipProvider>
-          <a className="skip-link" href="#main-content">
-            Skip to main content
-          </a>
-          <Toaster />
-          <Sonner />
-          <BrowserRouter>
-            <Suspense fallback={<div className="p-4">Loading...</div>}>
-              <Routes>
-                <Route path="/" element={<Index />} />
-                <Route path="/privacy-policy" element={<PrivacyPolicy />} />
-                <Route path="/cookie-policy" element={<CookiePolicy />} />
-                <Route path="/community/prompts" element={<CommunityPrompts />} />
-                <Route path="/community/submit" element={<SubmitPrompt />} />
-                <Route path="/tools" element={<ToolsMarketplace />} />
-                <Route path="/creator/dashboard" element={<CreatorDashboard />} />
-                <Route path="/creator/onboarding" element={<CreatorOnboarding />} />
-                <Route path="/creator/submit" element={<CreatorSubmitTool />} />
-                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-                <Route path="*" element={<NotFound />} />
-              </Routes>
+      <LanguageProvider>
+        <QueryClientProvider client={queryClient}>
+          <TooltipProvider>
+            <a className="skip-link" href="#main-content">
+              Skip to main content
+            </a>
+            <Toaster />
+            <Sonner />
+            <BrowserRouter>
+              <Suspense fallback={<div className="p-4">Loading...</div>}>
+                <Routes>
+                  <Route path="/" element={<Index />} />
+                  <Route path="/marketplace" element={<Marketplace />} />
+                  <Route path="/exchange" element={<Exchange />} />
+                  <Route path="/creators" element={<Creators />} />
+                  <Route path="/enterprise" element={<Enterprise />} />
+                  <Route path="/pricing" element={<Pricing />} />
+                  <Route path="/insights" element={<Insights />} />
+                  <Route path="/support" element={<Support />} />
+                  <Route path="/privacy-policy" element={<PrivacyPolicy />} />
+                  <Route path="/cookie-policy" element={<CookiePolicy />} />
+                  <Route path="/community/prompts" element={<CommunityPrompts />} />
+                  <Route path="/community/submit" element={<SubmitPrompt />} />
+                  <Route path="/tools" element={<ToolsMarketplace />} />
+                  <Route path="/creator/dashboard" element={<CreatorDashboard />} />
+                  <Route path="/creator/onboarding" element={<CreatorOnboarding />} />
+                  <Route path="/creator/submit" element={<CreatorSubmitTool />} />
+                  {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                  <Route path="*" element={<NotFound />} />
+                </Routes>
+              </Suspense>
+            </BrowserRouter>
+            <CookieConsent />
+            <Suspense fallback={null}>
+              <LazyMediumSubscriptionPopup />
             </Suspense>
-          </BrowserRouter>
-          <EnvironmentDebug />
-        </TooltipProvider>
-      </QueryClientProvider>
+            <Suspense fallback={null}>
+              <LazyNewsletterConversionPopup />
+            </Suspense>
+            <EnvironmentDebug />
+          </TooltipProvider>
+        </QueryClientProvider>
+      </LanguageProvider>
     </HelmetProvider>
   );
 };

--- a/src/components/FinalCTA.tsx
+++ b/src/components/FinalCTA.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 const FinalCTA = () => {
@@ -31,27 +32,27 @@ const FinalCTA = () => {
                 {isEnglish ? "Choose your path" : "আপনার পথ বেছে নিন"}
               </p>
               <div className="grid gap-3 text-sm font-semibold text-foreground">
-                <a
-                  href="/community/submit"
+                <Link
+                  to="/community/submit"
                   className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Creator onboarding" : "ক্রিয়েটর অনবোর্ডিং"}</span>
                   <span aria-hidden className="text-emerald-700">→</span>
-                </a>
-                <a
-                  href="#enterprise"
+                </Link>
+                <Link
+                  to="/enterprise"
                   className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Enterprise discovery" : "এন্টারপ্রাইজ ডিসকভারি"}</span>
                   <span aria-hidden className="text-emerald-700">→</span>
-                </a>
-                <a
-                  href="#insights"
+                </Link>
+                <Link
+                  to="/insights"
                   className="flex items-center justify-between rounded-2xl border border-emerald-100 bg-emerald-50/80 px-4 py-3 transition-all hover:bg-emerald-100/80"
                 >
                   <span>{isEnglish ? "Download insights" : "ইনসাইটস ডাউনলোড"}</span>
                   <span aria-hidden className="text-emerald-700">→</span>
-                </a>
+                </Link>
               </div>
 
               <div className="rounded-2xl border border-emerald-100 bg-emerald-50/90 p-4 text-sm text-muted-foreground">

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 
@@ -6,28 +7,28 @@ const footerLinks = [
     headingEn: "Product",
     headingBn: "প্রোডাক্ট",
     links: [
-      { labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস", href: "#marketplace" },
-      { labelEn: "Live Bidding", labelBn: "লাইভ বিডিং", href: "#exchange" },
-      { labelEn: "Creator Hub", labelBn: "ক্রিয়েটর হাব", href: "#creators" },
-      { labelEn: "Pricing", labelBn: "প্রাইসিং", href: "#pricing" },
+      { labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস", to: "/marketplace" },
+      { labelEn: "Live Bidding", labelBn: "লাইভ বিডিং", to: "/exchange" },
+      { labelEn: "Creator Hub", labelBn: "ক্রিয়েটর হাব", to: "/creators" },
+      { labelEn: "Pricing", labelBn: "প্রাইসিং", to: "/pricing" },
     ],
   },
   {
     headingEn: "Solutions",
     headingBn: "সমাধান",
     links: [
-      { labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ", href: "#enterprise" },
-      { labelEn: "Compliance", labelBn: "কমপ্লায়েন্স", href: "#enterprise" },
-      { labelEn: "Insights", labelBn: "ইনসাইটস", href: "#insights" },
+      { labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ", to: "/enterprise" },
+      { labelEn: "Compliance", labelBn: "কমপ্লায়েন্স", to: "/enterprise" },
+      { labelEn: "Insights", labelBn: "ইনসাইটস", to: "/insights" },
     ],
   },
   {
     headingEn: "Company",
     headingBn: "কোম্পানি",
     links: [
-      { labelEn: "Support", labelBn: "সাপোর্ট", href: "#support" },
-      { labelEn: "Community", labelBn: "কমিউনিটি", href: "/community/prompts" },
-      { labelEn: "Security", labelBn: "সিকিউরিটি", href: "#enterprise" },
+      { labelEn: "Support", labelBn: "সাপোর্ট", to: "/support" },
+      { labelEn: "Community", labelBn: "কমিউনিটি", to: "/community/prompts" },
+      { labelEn: "Security", labelBn: "সিকিউরিটি", to: "/enterprise" },
     ],
   },
 ];
@@ -106,9 +107,9 @@ const Footer = () => {
               <ul className="mt-4 space-y-3 text-sm text-white/70">
                 {group.links.map((link) => (
                   <li key={link.labelEn}>
-                    <a href={link.href} className="transition-colors hover:text-white">
+                    <Link to={link.to} className="transition-colors hover:text-white">
                       {isEnglish ? link.labelEn : link.labelBn}
-                    </a>
+                    </Link>
                   </li>
                 ))}
               </ul>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,4 +1,5 @@
 import { useId } from "react";
+import { Link } from "react-router-dom";
 import { useLanguage } from "@/contexts/LanguageContext";
 
 const marketplaceStats = [
@@ -63,7 +64,6 @@ const Hero = () => {
 
   return (
     <section
-      id="main-content"
       aria-labelledby={headingId}
       aria-describedby={ariaDescription}
       tabIndex={-1}
@@ -138,20 +138,20 @@ const Hero = () => {
                 </ul>
 
                 <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-center">
-                  <a
-                    href="#marketplace"
+                  <Link
+                    to="/marketplace"
                     aria-describedby={ctaSupportId}
                     className="rounded-full bg-gradient-to-r from-emerald-600 via-emerald-500 to-sungold-500 px-8 py-3 text-center text-base font-semibold text-white shadow-[0_20px_45px_-18px_rgba(34,94,56,0.55)] transition-transform duration-200 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--emerald))]"
                   >
                     <span className="block">{isEnglish ? "Browse Marketplace" : "মার্কেটপ্লেস দেখুন"}</span>
-                  </a>
-                  <a
-                    href="#creators"
+                  </Link>
+                  <Link
+                    to="/creators"
                     aria-describedby={ctaSupportId}
                     className="rounded-full border border-emerald-300 bg-white px-8 py-3 text-center text-base font-semibold text-foreground shadow-[0_18px_40px_-20px_rgba(217,119,6,0.4)] transition-transform duration-200 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[hsl(var(--sungold))]"
                   >
                     <span className="block">{isEnglish ? "Start Selling Prompts" : "প্রম্পট বিক্রি শুরু করুন"}</span>
-                  </a>
+                  </Link>
                 </div>
 
                 <p id={ctaSupportId} className="text-sm text-muted-foreground">

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,26 +1,17 @@
 import { useEffect, useState } from "react";
+import { Link, NavLink } from "react-router-dom";
 import { Globe2, Menu, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useLanguage } from "@/contexts/LanguageContext";
 
-const navLinks = [
-  { href: "#marketplace", labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস" },
-  { href: "#exchange", labelEn: "Live Bids", labelBn: "লাইভ বিড" },
-  { href: "#creators", labelEn: "For Creators", labelBn: "ক্রিয়েটরদের জন্য" },
-  { href: "#enterprise", labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ" },
-  { href: "#pricing", labelEn: "Pricing", labelBn: "প্রাইসিং" },
-  { href: "#insights", labelEn: "Insights", labelBn: "ইনসাইটস" },
-  { href: "#support", labelEn: "Support", labelBn: "সাপোর্ট" },
-];
-
 const NAV_LINKS = [
-  { href: "#marketplace", labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস" },
-  { href: "#exchange", labelEn: "Live Bids", labelBn: "লাইভ বিড" },
-  { href: "#creators", labelEn: "For Creators", labelBn: "ক্রিয়েটরদের জন্য" },
-  { href: "#enterprise", labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ" },
-  { href: "#pricing", labelEn: "Pricing", labelBn: "প্রাইসিং" },
-  { href: "#insights", labelEn: "Insights", labelBn: "ইনসাইটস" },
-  { href: "#support", labelEn: "Support", labelBn: "সাপোর্ট" },
+  { to: "/marketplace", labelEn: "Marketplace", labelBn: "মার্কেটপ্লেস" },
+  { to: "/exchange", labelEn: "Live Bids", labelBn: "লাইভ বিড" },
+  { to: "/creators", labelEn: "For Creators", labelBn: "ক্রিয়েটরদের জন্য" },
+  { to: "/enterprise", labelEn: "Enterprise", labelBn: "এন্টারপ্রাইজ" },
+  { to: "/pricing", labelEn: "Pricing", labelBn: "প্রাইসিং" },
+  { to: "/insights", labelEn: "Insights", labelBn: "ইনসাইটস" },
+  { to: "/support", labelEn: "Support", labelBn: "সাপোর্ট" },
 ];
 
 type LanguageCode = "en" | "bn";
@@ -42,17 +33,20 @@ const Navbar = () => {
 
   const renderNavLinks = (className?: string) =>
     NAV_LINKS.map((link) => (
-      <a
-        key={link.href}
-        href={link.href}
-        className={cn(
-          "flex flex-col items-center text-xs font-medium text-muted-foreground/80 transition-colors hover:text-foreground md:text-[0.85rem]",
-          className,
-        )}
+      <NavLink
+        key={link.to}
+        to={link.to}
+        className={({ isActive }) =>
+          cn(
+            "flex flex-col items-center text-xs font-medium transition-colors md:text-[0.85rem]",
+            isActive ? "text-foreground" : "text-muted-foreground/80 hover:text-foreground",
+            className,
+          )
+        }
         onClick={() => setMenuOpen(false)}
       >
         <span>{isEnglish ? link.labelEn : link.labelBn}</span>
-      </a>
+      </NavLink>
     ));
 
   return (
@@ -65,7 +59,7 @@ const Navbar = () => {
       )}
     >
       <div className="mx-auto flex w-full max-w-7xl items-center justify-between px-4 py-4 md:px-8">
-        <a href="#top" className="flex items-center gap-3">
+        <Link to="/" className="flex items-center gap-3" onClick={() => setMenuOpen(false)}>
           <img
             src="/promptbazar-logo.svg"
             alt="PromptBazar.AI logo"
@@ -77,7 +71,7 @@ const Navbar = () => {
               Bengali Prompt Marketplace
             </span>
           </div>
-        </a>
+        </Link>
 
         <nav className="hidden items-center gap-6 lg:flex">{renderNavLinks()}</nav>
 
@@ -114,12 +108,13 @@ const Navbar = () => {
             <span>{isEnglish ? "Sign In" : "সাইন ইন"}</span>
           </a>
 
-          <a
-            href="#cta"
+          <Link
+            to="/pricing"
             className="rounded-full bg-[var(--gradient-aurora)] px-5 py-2 text-sm font-semibold text-white shadow-[var(--shadow-soft)] transition-all hover:-translate-y-0.5 hover:shadow-[var(--shadow-elevated)]"
+            onClick={() => setMenuOpen(false)}
           >
             <span>{isEnglish ? "Get Started" : "আজই শুরু করুন"}</span>
-          </a>
+          </Link>
         </div>
 
         <button
@@ -177,12 +172,13 @@ const Navbar = () => {
               >
                 <span className="block">{isEnglish ? "Sign In" : "সাইন ইন"}</span>
               </a>
-              <a
-                href="#cta"
+              <Link
+                to="/pricing"
                 className="rounded-xl bg-[var(--gradient-aurora)] px-4 py-3 text-sm font-semibold text-white shadow-[var(--shadow-soft)]"
+                onClick={() => setMenuOpen(false)}
               >
                 <span className="block">{isEnglish ? "Get Started" : "আজই শুরু করুন"}</span>
-              </a>
+              </Link>
             </div>
           </div>
         </div>

--- a/src/components/OptimizedAdLayout.tsx
+++ b/src/components/OptimizedAdLayout.tsx
@@ -5,35 +5,53 @@ interface OptimizedAdLayoutProps {
   children: React.ReactNode;
 }
 
-const OptimizedAdLayout: React.FC<OptimizedAdLayoutProps> = ({ children }) => {
-  const childArray = React.Children.toArray(children);
+const createInlineAd = (key: string) => (
+  <div
+    key={key}
+    className="flex w-full justify-center px-4"
+    aria-label="sponsored highlight"
+  >
+    <div className="inline-flex w-full max-w-xs flex-col items-center gap-2 rounded-2xl border border-border/40 bg-white/80 p-4 text-center shadow-[var(--shadow-soft)] backdrop-blur">
+      <span className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground/70">
+        Sponsored
+      </span>
+      <MonetizationAds placement="inline" className="mt-0 w-full" />
+    </div>
+  </div>
+);
 
-  const contentWithInlineAd = childArray.flatMap((child, index) => {
-    const segments = [child];
+const injectInlineAd = (nodes: React.ReactNode[], keyPrefix: string) =>
+  nodes.flatMap((node, index) => {
+    const segments = [node];
 
     if (index === 2) {
-      segments.push(
-        <div
-          key={`inline-ad-${index}`}
-          className="flex w-full justify-center px-4"
-          aria-label="sponsored highlight"
-        >
-          <div className="inline-flex w-full max-w-xs flex-col items-center gap-2 rounded-2xl border border-border/40 bg-white/80 p-4 text-center shadow-[var(--shadow-soft)] backdrop-blur">
-            <span className="text-[0.65rem] font-semibold uppercase tracking-[0.24em] text-muted-foreground/70">
-              Sponsored
-            </span>
-            <MonetizationAds placement="inline" className="mt-0 w-full" />
-          </div>
-        </div>
-      );
+      segments.push(createInlineAd(`${keyPrefix}-inline-ad-${index}`));
     }
 
     return segments;
   });
 
+const OptimizedAdLayout: React.FC<OptimizedAdLayoutProps> = ({ children }) => {
+  const childArray = React.Children.toArray(children);
+  const hasMainChild = childArray.some(
+    (child) => React.isValidElement(child) && child.type === "main",
+  );
+
+  const processedChildren = hasMainChild
+    ? childArray.map((child) => {
+        if (React.isValidElement(child) && child.type === "main") {
+          const mainChildren = React.Children.toArray(child.props.children);
+          const enhancedChildren = injectInlineAd(mainChildren, "main");
+          return React.cloneElement(child, child.props, enhancedChildren);
+        }
+
+        return child;
+      })
+    : injectInlineAd(childArray, "layout");
+
   return (
     <div className="relative flex min-h-screen flex-col bg-gradient-to-b from-white via-white to-muted/20">
-      <div className="flex-1 space-y-0">{contentWithInlineAd}</div>
+      <div className="flex-1 space-y-0">{processedChildren}</div>
 
       <div className="border-t border-border/30 bg-white/90 py-10 backdrop-blur">
         <div className="mx-auto flex max-w-sm flex-col items-center gap-3 px-4 text-center">

--- a/src/components/RootLayout.tsx
+++ b/src/components/RootLayout.tsx
@@ -1,0 +1,25 @@
+import { ReactNode, Children } from "react";
+import OptimizedAdLayout from "./OptimizedAdLayout";
+import Navbar from "./Navbar";
+import Footer from "./Footer";
+
+interface RootLayoutProps {
+  children: ReactNode;
+}
+
+const RootLayout = ({ children }: RootLayoutProps) => {
+  const content = Children.toArray(children);
+
+  return (
+    <OptimizedAdLayout>
+      <div id="top" aria-hidden="true" className="sr-only" />
+      <Navbar />
+      <main id="main-content" className="flex flex-col gap-0 pt-24">
+        {content}
+      </main>
+      <Footer />
+    </OptimizedAdLayout>
+  );
+};
+
+export default RootLayout;

--- a/src/pages/Creators.tsx
+++ b/src/pages/Creators.tsx
@@ -1,0 +1,54 @@
+import React, { Suspense } from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import GlobalCommunity from "@/components/GlobalCommunity";
+import { LazyPromptTemplates } from "@/components/LazyComponents";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const SectionLoader = () => (
+  <div className="flex items-center justify-center py-12">
+    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+  </div>
+);
+
+const Creators = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Creator Hub | PromptBazar.AI"
+        description="Design storefronts, package bilingual prompt templates, and connect with the PromptBazar.AI community."
+        url="https://promptbazaar.ai/creators"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Creator hub" : "ক্রিয়েটর হাব"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Launch and scale bilingual prompt storefronts"
+                : "দ্বিভাষিক প্রম্পট স্টোরফ্রন্ট চালু ও স্কেল করুন"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Access templates, workflows, and community data to grow as a PromptBazar.AI creator."
+                : "PromptBazar.AI ক্রিয়েটর হিসেবে এগিয়ে যেতে টেমপ্লেট, ওয়ার্কফ্লো ও কমিউনিটি ডেটা ব্যবহার করুন।"}
+            </p>
+          </div>
+        </section>
+        <Suspense fallback={<SectionLoader />}>
+          <LazyPromptTemplates />
+        </Suspense>
+        <GlobalCommunity />
+      </RootLayout>
+    </>
+  );
+};
+
+export default Creators;

--- a/src/pages/Enterprise.tsx
+++ b/src/pages/Enterprise.tsx
@@ -1,0 +1,52 @@
+import React, { Suspense } from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import { LazyAbout } from "@/components/LazyComponents";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const SectionLoader = () => (
+  <div className="flex items-center justify-center py-12">
+    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+  </div>
+);
+
+const Enterprise = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Enterprise Solutions | PromptBazar.AI"
+        description="Assess compliance, localisation, and deployment workflows crafted for enterprise AI teams in Bangladesh and beyond."
+        url="https://promptbazaar.ai/enterprise"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Enterprise" : "এন্টারপ্রাইজ"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Compliance, procurement, and localisation pathways"
+                : "কমপ্লায়েন্স, প্রোকিউরমেন্ট ও লোকালাইজেশনের পথ"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Equip enterprise stakeholders with audit trails, bilingual packaging, and governance-ready tooling."
+                : "এন্টারপ্রাইজ স্টেকহোল্ডারদের জন্য অডিট ট্রেইল, দ্বিভাষিক প্যাকেজিং ও গভর্নেন্স-প্রস্তুত টুলিং সরবরাহ করুন।"}
+            </p>
+          </div>
+        </section>
+        <Suspense fallback={<SectionLoader />}>
+          <LazyAbout />
+        </Suspense>
+      </RootLayout>
+    </>
+  );
+};
+
+export default Enterprise;

--- a/src/pages/Exchange.tsx
+++ b/src/pages/Exchange.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import BidExchange from "@/components/BidExchange";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const Exchange = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Live Bidding Exchange | PromptBazar.AI"
+        description="Access real-time bidding dashboards, liquidity signals, and auction workflows for Bengali AI prompts."
+        url="https://promptbazaar.ai/exchange"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Live bidding" : "লাইভ বিডিং"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Liquidity intelligence for prompt auctions"
+                : "প্রম্পট নিলামের জন্য লিকুইডিটি ইন্টেলিজেন্স"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Monitor exchange health, buyer demand, and deal velocity to activate the right prompt bundles."
+                : "এক্সচেঞ্জের স্বাস্থ্য, ক্রেতার চাহিদা ও চুক্তির গতি পর্যবেক্ষণ করে সঠিক প্রম্পট বান্ডেল সক্রিয় করুন।"}
+            </p>
+          </div>
+        </section>
+        <BidExchange />
+      </RootLayout>
+    </>
+  );
+};
+
+export default Exchange;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,95 +1,121 @@
-import React, { Suspense } from "react";
+import React from "react";
+import { Link } from "react-router-dom";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import SEOHead from "@/components/SEOHead";
 import SecurityHeaders from "@/components/SecurityHeaders";
 import PerformanceOptimizer from "@/components/PerformanceOptimizer";
-import Navbar from "@/components/Navbar";
 import Hero from "@/components/Hero";
-import Features from "@/components/Features";
-import OptimizedAdLayout from "@/components/OptimizedAdLayout";
-import BidExchange from "@/components/BidExchange";
-import CookieConsent from "@/components/CookieConsent";
-import {
-  LazyAdvancedPatterns,
-  LazyPromptTemplates,
-  LazyAbout,
-  LazyContact,
-  LazyMediumSubscriptionPopup,
-  LazyNewsletterConversionPopup
-} from "@/components/LazyComponents";
-import Footer from "@/components/Footer";
-import PricingTransparency from "@/components/PricingTransparency";
-import GlobalCommunity from "@/components/GlobalCommunity";
-import InsightsHub from "@/components/InsightsHub";
 import FinalCTA from "@/components/FinalCTA";
-import { LanguageProvider } from "@/contexts/LanguageContext";
+import RootLayout from "@/components/RootLayout";
+import { useLanguage } from "@/contexts/LanguageContext";
 
-
-// Loading fallback component
-const LoadingFallback = () => (
-  <div className="flex items-center justify-center py-12">
-    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
-  </div>
-);
+const discoveryLinks = [
+  {
+    to: "/marketplace",
+    titleEn: "Marketplace",
+    titleBn: "মার্কেটপ্লেস",
+    descriptionEn: "Discover curated Bengali-first prompts and industry bundles.",
+    descriptionBn: "বাংলা-প্রথম কিউরেটেড প্রম্পট ও ইন্ডাস্ট্রি বান্ডেল আবিষ্কার করুন।",
+  },
+  {
+    to: "/exchange",
+    titleEn: "Live bidding",
+    titleBn: "লাইভ বিডিং",
+    descriptionEn: "Match demand with real-time liquidity signals from verified buyers.",
+    descriptionBn: "যাচাইকৃত ক্রেতাদের রিয়েল-টাইম চাহিদা সংকেতের সাথে লেনদেন মিল করুন।",
+  },
+  {
+    to: "/creators",
+    titleEn: "Creator hub",
+    titleBn: "ক্রিয়েটর হাব",
+    descriptionEn: "Package storefronts, prompt templates, and global launch playbooks.",
+    descriptionBn: "স্টোরফ্রন্ট, প্রম্পট টেমপ্লেট ও গ্লোবাল লঞ্চ প্লেবুক সাজিয়ে তুলুন।",
+  },
+  {
+    to: "/enterprise",
+    titleEn: "Enterprise",
+    titleBn: "এন্টারপ্রাইজ",
+    descriptionEn: "Review compliance, localisation, and integration paths for teams.",
+    descriptionBn: "টিমের জন্য কমপ্লায়েন্স, লোকালাইজেশন ও ইন্টিগ্রেশন পথ মূল্যায়ন করুন।",
+  },
+  {
+    to: "/pricing",
+    titleEn: "Pricing",
+    titleBn: "প্রাইসিং",
+    descriptionEn: "Model revenue splits, subscriptions, and predictive royalty flows.",
+    descriptionBn: "রাজস্ব ভাগ, সাবস্ক্রিপশন ও প্রেডিক্টিভ রয়্যালটির পরিকল্পনা করুন।",
+  },
+  {
+    to: "/insights",
+    titleEn: "Insights",
+    titleBn: "ইনসাইটস",
+    descriptionEn: "Download research on the 2025 Bengali creator economy and AI ops.",
+    descriptionBn: "২০২৫ বাংলা ক্রিয়েটর ইকোনমি ও এআই অপারেশনের গবেষণা ডাউনলোড করুন।",
+  },
+];
 
 const Index = () => {
-  // Initialize analytics tracking
   useAnalytics();
-  
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
   return (
-    <LanguageProvider>
-      <div className="min-h-screen">
-        <div id="top" aria-hidden="true" className="sr-only" />
-        <SEOHead />
-        <SecurityHeaders />
-        <PerformanceOptimizer />
-
-        <OptimizedAdLayout>
-        <Navbar />
+    <>
+      <SEOHead />
+      <SecurityHeaders />
+      <PerformanceOptimizer />
+      <RootLayout>
         <Hero />
-        <Features />
-        <BidExchange />
+        <section className="section bg-gradient-to-b from-white via-white to-muted/20">
+          <div className="mx-auto max-w-7xl px-4 md:px-8">
+            <div className="mx-auto max-w-3xl text-center">
+              <p className="section-eyebrow">
+                {isEnglish ? "Explore the platform" : "প্ল্যাটফর্ম অন্বেষণ করুন"}
+              </p>
+              <h2 className="section-heading">
+                {isEnglish
+                  ? "Structured routes for every team"
+                  : "প্রতিটি টিমের জন্য সাজানো পথ"}
+              </h2>
+              <p className="section-subheading mt-4 text-muted-foreground">
+                {isEnglish
+                  ? "Navigate focused pages for marketplace discovery, bidding intelligence, creator tooling, enterprise compliance, and customer care."
+                  : "মার্কেটপ্লেস, বিডিং ইন্টেলিজেন্স, ক্রিয়েটর টুলিং, এন্টারপ্রাইজ কমপ্লায়েন্স ও সাপোর্টের জন্য আলাদা পৃষ্ঠায় দ্রুত পৌঁছে যান।"}
+              </p>
+            </div>
 
-        {/* Lazy loaded components for better performance */}
-        <Suspense fallback={<LoadingFallback />}>
-          <LazyAdvancedPatterns />
-        </Suspense>
-
-        <Suspense fallback={<LoadingFallback />}>
-          <LazyPromptTemplates />
-        </Suspense>
-
-        <PricingTransparency />
-
-        <Suspense fallback={<LoadingFallback />}>
-          <LazyAbout />
-        </Suspense>
-
-        <GlobalCommunity />
-        <InsightsHub />
-
-        <Suspense fallback={<LoadingFallback />}>
-          <LazyContact />
-        </Suspense>
-
+            <div className="mt-16 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {discoveryLinks.map((item) => (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className="group flex h-full flex-col justify-between rounded-3xl border border-emerald-100/60 bg-white/90 p-6 text-left shadow-[var(--shadow-soft)] transition-transform hover:-translate-y-1 hover:shadow-[var(--shadow-elevated)] focus-visible:outline focus-visible:outline-emerald-500/60 focus-visible:outline-offset-2"
+                >
+                  <div className="space-y-4">
+                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-700/80">
+                      {isEnglish ? "Navigate" : "ন্যাভিগেট"}
+                    </span>
+                    <h3 className="text-xl font-semibold text-foreground">
+                      {isEnglish ? item.titleEn : item.titleBn}
+                    </h3>
+                    <p className="text-sm text-muted-foreground">
+                      {isEnglish ? item.descriptionEn : item.descriptionBn}
+                    </p>
+                  </div>
+                  <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-emerald-700">
+                    {isEnglish ? "View page" : "পৃষ্ঠা দেখুন"}
+                    <span aria-hidden className="transition-transform group-hover:translate-x-1">
+                      →
+                    </span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </div>
+        </section>
         <FinalCTA />
-
-        <Footer />
-      </OptimizedAdLayout>
-      
-      {/* GDPR Cookie Consent */}
-      <CookieConsent />
-      
-      {/* Lazy loaded popups */}
-      <Suspense fallback={null}>
-        <LazyMediumSubscriptionPopup />
-      </Suspense>
-      
-      <Suspense fallback={null}>
-        <LazyNewsletterConversionPopup />
-      </Suspense>
-      </div>
-    </LanguageProvider>
+      </RootLayout>
+    </>
   );
 };
 

--- a/src/pages/Insights.tsx
+++ b/src/pages/Insights.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import InsightsHub from "@/components/InsightsHub";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const Insights = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Insights & Research | PromptBazar.AI"
+        description="Download research, playbooks, and measurement frameworks for Bengali AI localisation and marketplace growth."
+        url="https://promptbazaar.ai/insights"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Insights" : "ইনসাইটস"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Research and measurement for Bengali AI"
+                : "বাংলা এআইয়ের জন্য গবেষণা ও মেজারমেন্ট"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Stay ahead with localisation reports, governance templates, and performance benchmarks."
+                : "লোকালাইজেশন রিপোর্ট, গভর্নেন্স টেমপ্লেট ও পারফরম্যান্স বেঞ্চমার্কের মাধ্যমে এগিয়ে থাকুন।"}
+            </p>
+          </div>
+        </section>
+        <InsightsHub />
+      </RootLayout>
+    </>
+  );
+};
+
+export default Insights;

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -1,412 +1,54 @@
-import { useMemo, useState } from "react"
-import { useMutation, useQuery } from "@tanstack/react-query"
-import {
-  AlertCircle,
-  Search,
-  ShieldCheck,
-  ShoppingCart,
-  Sparkles,
-  TrendingUp,
-} from "lucide-react"
+import React, { Suspense } from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import Features from "@/components/Features";
+import { LazyAdvancedPatterns } from "@/components/LazyComponents";
+import { useLanguage } from "@/contexts/LanguageContext";
 
-import SEOHead from "@/components/SEOHead"
-import {
-  Alert,
-  AlertDescription,
-  AlertTitle,
-} from "@/components/ui/alert"
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Skeleton } from "@/components/ui/skeleton"
-import { useToast } from "@/hooks/use-toast"
-import {
-  fetchMarketplacePrompts,
-  formatCurrency,
-  purchaseMarketplacePrompt,
-} from "@/integrations/marketplace"
-import type { MarketplacePrompt } from "@/types/marketplace"
+const SectionLoader = () => (
+  <div className="flex items-center justify-center py-12">
+    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+  </div>
+);
 
 const Marketplace = () => {
-  const { toast } = useToast()
-  const [searchTerm, setSearchTerm] = useState("")
-  const [selectedTag, setSelectedTag] = useState<string | null>(null)
-  const [activePrompt, setActivePrompt] = useState<MarketplacePrompt | null>(
-    null,
-  )
-  const [buyerEmail, setBuyerEmail] = useState("")
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-
-  const {
-    data: prompts = [],
-    isLoading,
-    isError,
-    error,
-  } = useQuery({
-    queryKey: ["marketplace", "prompts"],
-    queryFn: fetchMarketplacePrompts,
-    staleTime: 60_000,
-  })
-
-  const availableTags = useMemo(() => {
-    const tagSet = new Set<string>()
-    prompts.forEach((prompt) => {
-      prompt.tags.forEach((tag) => {
-        if (tag) {
-          tagSet.add(tag)
-        }
-      })
-    })
-
-    return Array.from(tagSet).sort((a, b) => a.localeCompare(b))
-  }, [prompts])
-
-  const filteredPrompts = useMemo(() => {
-    if (!prompts.length) {
-      return []
-    }
-
-    const normalized = searchTerm.trim().toLowerCase()
-
-    return prompts.filter((prompt) => {
-      const matchesTag = selectedTag ? prompt.tags.includes(selectedTag) : true
-
-      if (!normalized) {
-        return matchesTag
-      }
-
-      const haystacks = [
-        prompt.title,
-        prompt.description ?? "",
-        prompt.authorName,
-        prompt.tags.join(" "),
-      ].map((value) => value.toLowerCase())
-
-      const matchesSearch = haystacks.some((value) => value.includes(normalized))
-
-      return matchesTag && matchesSearch
-    })
-  }, [prompts, searchTerm, selectedTag])
-
-  const purchaseMutation = useMutation({
-    mutationFn: purchaseMarketplacePrompt,
-    onSuccess: (result) => {
-      toast({
-        title: "ক্রয় সফল", // Purchase Successful
-        description: `আপনার মোট মূল্য ${formatCurrency(result.saleAmountCents)}। প্রম্পটটি এখন আপনার ইমেইলে পাঠানো হবে।`,
-      })
-      setIsDialogOpen(false)
-      setActivePrompt(null)
-      setBuyerEmail("")
-    },
-    onError: (mutationError) => {
-      const description =
-        mutationError instanceof Error
-          ? mutationError.message
-          : "অজানা কারণে পেমেন্ট সম্পন্ন হয়নি।" // Unknown error
-      toast({
-        title: "ক্রয় ব্যর্থ", // Purchase failed
-        description,
-        variant: "destructive",
-      })
-    },
-  })
-
-  const openPurchaseDialog = (prompt: MarketplacePrompt) => {
-    setActivePrompt(prompt)
-    setIsDialogOpen(true)
-  }
-
-  const handleDialogChange = (open: boolean) => {
-    setIsDialogOpen(open)
-    if (!open) {
-      setActivePrompt(null)
-      setBuyerEmail("")
-    }
-  }
-
-  const handleConfirmPurchase = () => {
-    if (!activePrompt) {
-      return
-    }
-
-    purchaseMutation.mutate({
-      promptId: activePrompt.id,
-      buyerEmail: buyerEmail.trim() || undefined,
-    })
-  }
-
-  const renderLoadingState = () => (
-    <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {Array.from({ length: 6 }).map((_, index) => (
-        <Card key={`skeleton-${index}`} className="border border-orange-100/60">
-          <CardHeader>
-            <Skeleton className="h-6 w-3/4" />
-            <Skeleton className="h-4 w-full" />
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <Skeleton className="h-4 w-full" />
-            <Skeleton className="h-4 w-5/6" />
-            <Skeleton className="h-4 w-2/3" />
-          </CardContent>
-          <CardFooter className="flex justify-between items-center">
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-20" />
-          </CardFooter>
-        </Card>
-      ))}
-    </div>
-  )
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-amber-50 via-rose-50 to-orange-100">
+    <>
       <SEOHead
-        title="বাজার - প্রিমিয়াম প্রম্পট মার্কেটপ্লেস"
-        description="বিশ্বস্ত বাংলা প্রম্পট নির্মাতাদের কাছ থেকে প্রিমিয়াম প্রম্পট কিনুন এবং আপনার নিজস্ব সংগ্রহ তৈরি করুন।"
-        url="https://promptshiksha.com/marketplace"
-        keywords="Bangla prompt marketplace, premium prompts, বাংলা প্রম্পট"
+        title="Marketplace | PromptBazar.AI"
+        description="Explore curated Bengali-first AI prompts, storefront capabilities, and marketplace intelligence tailored for creators and buyers."
+        url="https://promptbazaar.ai/marketplace"
       />
-
-      <section className="border-b border-orange-200/60 bg-white/80 backdrop-blur">
-        <div className="container mx-auto px-4 py-16 text-center">
-          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-orange-500 to-rose-500 text-white shadow-lg">
-            <ShoppingCart className="h-6 w-6" />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Marketplace" : "মার্কেটপ্লেস"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Curated Bengali-first prompt commerce"
+                : "বাংলা-প্রথম কিউরেটেড প্রম্পট কমার্স"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Review the marketplace value pillars, bidding analytics, and prompt discovery flows that power PromptBazar.AI."
+                : "PromptBazar.AI-এর মার্কেটপ্লেসের ভ্যালু পিলার, বিডিং অ্যানালিটিক্স এবং প্রম্পট ডিসকভারি ফ্লো সম্পর্কে জানুন।"}
+            </p>
           </div>
-          <h1 className="mt-6 text-3xl font-extrabold tracking-tight text-slate-900 md:text-4xl">
-            বাংলা প্রম্পট মার্কেটপ্লেস
-          </h1>
-          <p className="mx-auto mt-4 max-w-2xl text-base text-slate-600 md:text-lg">
-            শীর্ষস্থানীয় প্রম্পট নির্মাতাদের দক্ষতা দিয়ে তৈরি প্রিমিয়াম প্রম্পট সংগ্রহ। যাচাই করা ফর্মুলা ও বাংলা কনটেক্সটে অপ্টিমাইজড স্ট্র্যাটেজি দিয়ে আপনার জেনারেটিভ এআই ফলাফল উন্নত করুন।
-          </p>
-          <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
-            <div className="flex items-center gap-2 rounded-full bg-emerald-100 px-4 py-2 text-emerald-700">
-              <ShieldCheck className="h-5 w-5" />
-              <span>নিরাপদ ডিজিটাল পেমেন্ট</span>
-            </div>
-            <div className="flex items-center gap-2 rounded-full bg-amber-100 px-4 py-2 text-amber-700">
-              <TrendingUp className="h-5 w-5" />
-              <span>কমিশন ট্র্যাকিং স্বয়ংক্রিয়</span>
-            </div>
-            <div className="flex items-center gap-2 rounded-full bg-rose-100 px-4 py-2 text-rose-700">
-              <Sparkles className="h-5 w-5" />
-              <span>কমিউনিটি যাচাইকৃত নির্মাতা</span>
-            </div>
-          </div>
-        </div>
-      </section>
+        </section>
+        <Features />
+        <Suspense fallback={<SectionLoader />}>
+          <LazyAdvancedPatterns />
+        </Suspense>
+      </RootLayout>
+    </>
+  );
+};
 
-      <main className="container mx-auto px-4 py-16">
-        <div className="flex flex-col gap-6 rounded-3xl bg-white/80 p-8 shadow-xl shadow-orange-200/40">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <h2 className="text-2xl font-semibold text-slate-900">
-                প্রিমিয়াম প্রম্পট সংগ্রহ
-              </h2>
-              <p className="mt-1 text-sm text-slate-600">
-                পারফরমেন্স প্রমাণিত প্রম্পট গুলো থেকে বেছে নিন। প্রতিটি ক্রয়ে নির্মাতার জন্য স্বয়ংক্রিয় কমিশন রেকর্ড হয়।
-              </p>
-            </div>
-            <div className="relative w-full md:w-80">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
-              <Input
-                value={searchTerm}
-                onChange={(event) => setSearchTerm(event.target.value)}
-                placeholder="প্রম্পট খুঁজুন..."
-                className="pl-10"
-              />
-            </div>
-          </div>
-
-          {availableTags.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2">
-              <span className="text-sm font-medium text-slate-600">শ্রেণি:</span>
-              {availableTags.map((tag) => {
-                const isActive = selectedTag === tag
-                return (
-                  <Badge
-                    key={tag}
-                    variant={isActive ? "default" : "secondary"}
-                    className={`cursor-pointer px-3 py-1 ${
-                      isActive
-                        ? "bg-orange-500 text-white hover:bg-orange-500"
-                        : "bg-orange-100/80 text-orange-700 hover:bg-orange-200"
-                    }`}
-                    onClick={() => setSelectedTag(isActive ? null : tag)}
-                  >
-                    #{tag}
-                  </Badge>
-                )
-              })}
-              {selectedTag && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setSelectedTag(null)}
-                >
-                  ফিল্টার রিসেট
-                </Button>
-              )}
-            </div>
-          )}
-
-          {isError && (
-            <Alert variant="destructive">
-              <AlertCircle className="h-4 w-4" />
-              <AlertTitle>ডেটা লোড ব্যর্থ</AlertTitle>
-              <AlertDescription>
-                {error instanceof Error
-                  ? error.message
-                  : "সার্ভার থেকে তথ্য আনতে সমস্যা হচ্ছে। কিছুক্ষণ পরে আবার চেষ্টা করুন।"}
-              </AlertDescription>
-            </Alert>
-          )}
-
-          {isLoading && renderLoadingState()}
-
-          {!isLoading && filteredPrompts.length === 0 && (
-            <Card className="border border-dashed border-orange-200 bg-orange-50/70 text-center">
-              <CardHeader>
-                <CardTitle className="text-xl text-slate-800">
-                  কোন প্রম্পট পাওয়া যায়নি
-                </CardTitle>
-                <CardDescription>
-                  আপনার সার্চ বা ফিল্টারের সাথে মিলে এমন কোন প্রম্পট এই মুহূর্তে নেই। ফিল্টার পরিবর্তন করে আবার চেষ্টা করুন।
-                </CardDescription>
-              </CardHeader>
-            </Card>
-          )}
-
-          {!isLoading && filteredPrompts.length > 0 && (
-            <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {filteredPrompts.map((prompt) => (
-                <Card
-                  key={prompt.id}
-                  className="group flex h-full flex-col border border-orange-100/80 bg-white/90 backdrop-blur transition hover:-translate-y-1 hover:shadow-lg hover:shadow-orange-200/60"
-                >
-                  <CardHeader>
-                    <CardTitle className="flex items-start justify-between gap-3 text-lg text-slate-900">
-                      <span>{prompt.title}</span>
-                      <Badge className="bg-gradient-to-r from-orange-500 to-rose-500 text-white">
-                        {formatCurrency(prompt.priceCents, prompt.currency)}
-                      </Badge>
-                    </CardTitle>
-                    <CardDescription className="line-clamp-3 text-sm text-slate-600">
-                      {prompt.description || "বিস্তারিত বিবরণ উপলভ্য।"}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent className="flex flex-1 flex-col gap-4">
-                    <div className="space-y-1 text-sm text-slate-500">
-                      <p className="font-medium text-slate-700">
-                        নির্মাতা: {prompt.authorName}
-                      </p>
-                      <p>কমিশন: {(prompt.commissionRate * 100).toFixed(0)}%</p>
-                    </div>
-                    <div className="flex flex-wrap gap-2">
-                      {prompt.tags.map((tag) => (
-                        <Badge
-                          key={`${prompt.id}-${tag}`}
-                          variant="outline"
-                          className="border-orange-200 text-orange-700"
-                        >
-                          #{tag}
-                        </Badge>
-                      ))}
-                    </div>
-                  </CardContent>
-                  <CardFooter className="mt-auto flex items-center justify-between">
-                    <div className="text-xs text-slate-500">
-                      সর্বশেষ আপডেট {new Date(prompt.updatedAt).toLocaleDateString("bn-BD")}
-                    </div>
-                    <Button onClick={() => openPurchaseDialog(prompt)}>
-                      <ShoppingCart className="mr-2 h-4 w-4" /> ক্রয় করুন
-                    </Button>
-                  </CardFooter>
-                </Card>
-              ))}
-            </div>
-          )}
-        </div>
-      </main>
-
-      <Dialog open={isDialogOpen} onOpenChange={handleDialogChange}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader>
-            <DialogTitle>প্রম্পট ক্রয় নিশ্চিতকরণ</DialogTitle>
-            <DialogDescription>
-              প্রম্পটটি কেনার জন্য নিচের তথ্য যাচাই করে নিশ্চিত করুন। পেমেন্ট সফল হলে ইমেইলের মাধ্যমে প্রম্পটটি পাঠানো হবে।
-            </DialogDescription>
-          </DialogHeader>
-
-          {activePrompt && (
-            <div className="space-y-4">
-              <div className="rounded-xl bg-orange-50/80 p-4 text-sm text-slate-700">
-                <p className="font-semibold text-slate-900">{activePrompt.title}</p>
-                <p className="mt-1 text-slate-600">
-                  মূল্য: {formatCurrency(activePrompt.priceCents, activePrompt.currency)}
-                </p>
-                <p className="text-slate-500">
-                  নির্মাতা কমিশন স্বয়ংক্রিয়ভাবে {(
-                    activePrompt.commissionRate * 100
-                  ).toFixed(0)}% হিসেবে যোগ হবে।
-                </p>
-              </div>
-
-              <div className="space-y-2">
-                <Label htmlFor="buyer-email">ইমেইল (ঐচ্ছিক)</Label>
-                <Input
-                  id="buyer-email"
-                  type="email"
-                  autoComplete="email"
-                  placeholder="আপনার ইমেইল লিখুন"
-                  value={buyerEmail}
-                  onChange={(event) => setBuyerEmail(event.target.value)}
-                  disabled={purchaseMutation.isPending}
-                />
-                <p className="text-xs text-slate-500">
-                  আমরা প্রম্পট ফাইল এবং ভবিষ্যৎ আপডেট এই ইমেইলে পাঠাবো।
-                </p>
-              </div>
-            </div>
-          )}
-
-          <DialogFooter className="gap-2 sm:gap-0">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleDialogChange(false)}
-              disabled={purchaseMutation.isPending}
-            >
-              বাতিল
-            </Button>
-            <Button
-              type="button"
-              onClick={handleConfirmPurchase}
-              disabled={purchaseMutation.isPending || !activePrompt}
-            >
-              {purchaseMutation.isPending ? "প্রসেস হচ্ছে..." : "পেমেন্ট সম্পন্ন করুন"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
-  )
-}
-
-export default Marketplace
+export default Marketplace;

--- a/src/pages/Pricing.tsx
+++ b/src/pages/Pricing.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import PricingTransparency from "@/components/PricingTransparency";
+import FinalCTA from "@/components/FinalCTA";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const Pricing = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Pricing & Revenue | PromptBazar.AI"
+        description="Understand revenue share, subscription tiers, and payout predictability for PromptBazar.AI creators and buyers."
+        url="https://promptbazaar.ai/pricing"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Pricing" : "প্রাইসিং"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "Transparent economics for every workflow"
+                : "প্রতিটি ওয়ার্কফ্লোর জন্য স্বচ্ছ ইকোনমিকস"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Model pricing for prompt bundles, subscriptions, and enterprise licensing with predictive payouts."
+                : "প্রম্পট বান্ডেল, সাবস্ক্রিপশন ও এন্টারপ্রাইজ লাইসেন্সিংয়ের জন্য প্রেডিক্টিভ পেআউটসহ প্রাইসিং মডেল করুন।"}
+            </p>
+          </div>
+        </section>
+        <PricingTransparency />
+        <FinalCTA />
+      </RootLayout>
+    </>
+  );
+};
+
+export default Pricing;

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,0 +1,54 @@
+import React, { Suspense } from "react";
+import { useAnalytics } from "@/hooks/useAnalytics";
+import SEOHead from "@/components/SEOHead";
+import RootLayout from "@/components/RootLayout";
+import FinalCTA from "@/components/FinalCTA";
+import { LazyContact } from "@/components/LazyComponents";
+import { useLanguage } from "@/contexts/LanguageContext";
+
+const SectionLoader = () => (
+  <div className="flex items-center justify-center py-12">
+    <div className="h-8 w-8 animate-spin rounded-full border-b-2 border-primary" />
+  </div>
+);
+
+const Support = () => {
+  useAnalytics();
+  const { language } = useLanguage();
+  const isEnglish = language === "en";
+
+  return (
+    <>
+      <SEOHead
+        title="Support & Contact | PromptBazar.AI"
+        description="Reach the PromptBazar.AI support desk for onboarding, billing, or compliance requests across Bengali and English."
+        url="https://promptbazaar.ai/support"
+      />
+      <RootLayout>
+        <section className="section pb-0">
+          <div className="mx-auto max-w-4xl px-4 text-center md:px-8">
+            <p className="section-eyebrow">
+              {isEnglish ? "Support" : "সাপোর্ট"}
+            </p>
+            <h1 className="section-heading">
+              {isEnglish
+                ? "72-hour bilingual support for every partner"
+                : "প্রতিটি পার্টনারের জন্য ৭২ ঘণ্টার দ্বিভাষিক সাপোর্ট"}
+            </h1>
+            <p className="section-subheading mt-4 text-muted-foreground">
+              {isEnglish
+                ? "Contact our team for onboarding, compliance reviews, marketplace questions, or dedicated enterprise care."
+                : "অনবোর্ডিং, কমপ্লায়েন্স রিভিউ, মার্কেটপ্লেস প্রশ্ন বা এন্টারপ্রাইজ সহায়তার জন্য আমাদের টিমের সাথে যোগাযোগ করুন।"}
+            </p>
+          </div>
+        </section>
+        <Suspense fallback={<SectionLoader />}>
+          <LazyContact />
+        </Suspense>
+        <FinalCTA />
+      </RootLayout>
+    </>
+  );
+};
+
+export default Support;


### PR DESCRIPTION
## Summary
- register dedicated routes for marketplace, bidding, creators, enterprise, pricing, insights, and support while moving the language provider to the app shell
- add a reusable RootLayout and enhance the optimized ad layout so routed pages share the same chrome without breaking inline ad placement
- streamline the home page into hero plus navigation tiles and update navigation, CTA, and footer links to use React Router for the new pages

## Testing
- yarn lint
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cdda97201c832697a3311760d10104