### PR TITLE
docs: expand product readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,92 +1,119 @@
 # Prompt Bangla AI
 
-A Bangla-first AI prompt selling and creator platform built with React, Vite and Supabase. The project showcases production-ready patterns for scaling, security and monetization while teaching prompt engineering in Bengali.
+> Bangladesh's first bilingual prompt marketplace for creators, enterprises, and buyers who need culturally relevant AI workflows.
 
+## Table of contents
+- [Overview](#overview)
+- [Core experiences](#core-experiences)
+- [Architecture](#architecture)
+- [Data model & Supabase setup](#data-model--supabase-setup)
+- [Edge & background services](#edge--background-services)
+- [Performance, security & compliance](#performance-security--compliance)
+- [Local development](#local-development)
+- [Quality checks](#quality-checks)
+- [Deployment](#deployment)
+- [Project structure](#project-structure)
+- [Community & support](#community--support)
 
-https://github.com/user-attachments/assets/8af407b6-86fe-437c-a91b-82882949769c
+## Overview
+Prompt Bangla AI is a production-ready Vite + React application that operates as a Bangla-first AI prompt marketplace. The experience ships with bilingual storytelling, creator monetisation tooling, enterprise procurement workflows, Supabase-powered analytics, and ad-driven revenue experiments. The interface highlights a creator-first go-to-market with live bidding, storefront packaging, and enterprise localisation guidance that speaks simultaneously to English and Bangla audiences.【F:src/components/Hero.tsx†L6-L136】【F:src/pages/Index.tsx†L1-L92】
 
+Key pillars:
+- **Bilingual UX** – persistent language context with local storage persistence drives an inclusive, toggleable Bangla/English interface across every surface.【F:src/contexts/LanguageContext.tsx†L1-L39】
+- **Creator revenue focus** – hero blocks, CTA flows, and marketplace navigation make it simple to publish prompt bundles, launch storefronts, and reach global buyers.【F:src/components/Hero.tsx†L6-L166】
+- **Enterprise trust** – compliance messaging, pricing transparency, and live bidding telemetry connect procurement teams to vetted creators with data-backed confidence.【F:src/components/Hero.tsx†L115-L166】【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L88】
+- **Monetisation mix** – built-in Google AdSense slots, ad exchanges, and newsletter conversions generate diversified revenue streams alongside marketplace sales.【F:src/App.tsx†L1-L87】【F:src/components/LazyComponents.tsx†L1-L26】
 
-## Features
+## Core experiences
+- **Marketplace discovery** – landing page routes guide visitors toward marketplace listings, live exchange dashboards, creator onboarding, enterprise localisation, pricing, and insights in both languages.【F:src/pages/Index.tsx†L11-L92】
+- **Creator storefront toolkit** – highlight cards position upload, licensing, analytics, and payouts with 72-hour SLA as the default onboarding path.【F:src/components/Hero.tsx†L6-L108】
+- **Enterprise localisation suite** – Supabase-backed pricing audiences and feature toggles let you manage enterprise messaging, compliance checklists, and CTA links without redeploying the app.【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L139】
+- **Live bidding exchange** – navigation emphasises real-time liquidity signals for verified buyers, reinforcing the differentiator for high-frequency prompt trading.【F:src/components/Hero.tsx†L25-L108】
+- **Community growth loops** – newsletter and Medium subscription popups are lazy-loaded to protect initial paint while capturing engaged traffic later in the session.【F:src/App.tsx†L13-L87】【F:src/components/LazyComponents.tsx†L9-L26】
+- **Global impact narrative** – hero storytelling codifies rankings, revenue uplift targets, and inclusive sectors (education, fintech, climate, creative) as part of the brand voice.【F:src/components/Hero.tsx†L108-L166】
 
-- **Prompt engineering guide in Bangla** – includes basic to advanced templates and best practices for writing effective prompts.
-- **Supabase backend** for newsletter subscriptions, contact form emails and real-time user analytics.
-- **Security & privacy tooling** such as strict Content Security Policy, XSS protection and GDPR‑style cookie consent.
-- **Performance optimizations** with lazy loaded sections, service worker caching and resource hinting for fast global delivery.
-- **Ad monetization** through Google AdSense and Adsterra placements.
-- **Deployment check** through github actions for cloudflare
+## Architecture
+The front end is a modular React 18 application with route-level code splitting, suspense fallbacks, and analytics instrumentation designed to scale past 1,000 concurrent users.【F:src/App.tsx†L1-L87】【F:SCALING_SUMMARY.md†L5-L49】
 
-## Tech Stack
+- **Routing & layout** – React Router v6 with lazy-loaded routes, shared layout primitives, skip links, and tooltip providers keep the UI accessible and responsive.【F:src/App.tsx†L1-L87】
+- **Design system** – Tailwind CSS + shadcn/ui supply composable UI primitives, while lucide-react icons, cva utilities, and custom gradients maintain brand consistency.【F:package.json†L14-L68】
+- **State & data** – TanStack Query handles Supabase data fetching with tuned cache, retry, and garbage collection windows to minimise chattiness while supporting realtime-ready workloads.【F:src/App.tsx†L33-L53】
+- **Analytics pipeline** – a resilient analytics tracker batches page views, scroll depth, and time-on-page events into Supabase with offline persistence, retry logic, and storage fallbacks for edge runtimes.【F:src/hooks/useAnalytics.ts†L1-L189】
+- **Internationalisation** – lightweight context avoids heavy i18n frameworks while still syncing document language, persisting preferences, and exposing hooks to child components.【F:src/contexts/LanguageContext.tsx†L1-L39】
 
-- React 18 + TypeScript
-- Vite build system
-- Tailwind CSS with shadcn/ui components
-- Supabase database & edge functions
-- Resend email API
-- yarn package manager
+## Data model & Supabase setup
+Supabase drives authentication, marketplace storage, analytics, and consent logs using row-level security (RLS) and PostgreSQL functions.
+
+Highlighted schema:
+- **Marketplace prompts & sales** – prompt listings, royalty splits, and purchase tracking ship with indexes, commission calculations, and seller-facing RLS policies.【F:supabase/migrations/20250720093000-add-marketplace-prompts.sql†L1-L141】
+- **Pricing transparency** – dynamic audience toggles, feature grids, and highlight cards are stored in Supabase for CMS-like control with service-role management policies.【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L139】
+- **Analytics events** – batched `user_analytics` inserts accept session metadata, device stats, and engagement metrics collected from the custom hook.【F:src/hooks/useAnalytics.ts†L1-L189】
+- **Contact pipeline** – the `contacts` table (seeded in earlier migrations) integrates with an edge function that validates, rate-limits, stores, and emails submissions using Resend.【F:supabase/functions/send-contact-email/index.ts†L1-L183】
+
+Supabase CLI workflow:
+```bash
+yarn dlx supabase@latest login
+yarn dlx supabase db push  # applies the SQL migrations in supabase/migrations
+```
+Ensure you supply `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` when running migrations remotely.
+
+## Edge & background services
+- **Cloudflare Pages Functions middleware** injects runtime environment variables (`SUPABASE_URL`, `SUPABASE_ANON_KEY`) into the browser at request time so the client can hydrate on the edge without bundling secrets.【F:functions/_middleware.ts†L1-L62】
+- **Supabase Edge Function** `send-contact-email` handles contact form submissions with strict schema validation (Zod), rate limiting, sanitisation, database persistence, and bilingual autoresponder emails via Resend.【F:supabase/functions/send-contact-email/index.ts†L1-L183】
+
+## Performance, security & compliance
+The application is pre-tuned for high-traffic scenarios, with detailed tracking in `SCALING_SUMMARY.md` outlining the improvements made for the 1,000+ concurrent user benchmark.【F:SCALING_SUMMARY.md†L1-L68】
+
+- **Code splitting & lazy loading** – route-level `React.lazy`, suspense boundaries, and targeted preloading reduce the first bundle by ~60%.【F:src/App.tsx†L1-L87】【F:src/components/LazyComponents.tsx†L1-L26】【F:SCALING_SUMMARY.md†L9-L21】
+- **Service worker & resource hints** – runtime optimizer adds DNS prefetch, preconnect, service worker caching, lazy image loading, and Web Vitals instrumentation for proactive monitoring.【F:src/components/PerformanceOptimizer.tsx†L1-L135】【F:SCALING_SUMMARY.md†L23-L33】
+- **Security headers** – CSP, XSS, frame, referrer, permissions, and HSTS headers are injected via Helmet to satisfy enterprise trust requirements.【F:src/components/SecurityHeaders.tsx†L1-L71】
+- **Cookie consent** – GDPR-aligned banner records granular preferences, defers analytics initialisation until approval, and offers policy links in Bangla.【F:src/components/CookieConsent.tsx†L1-L104】
+- **Environment diagnostics** – a development-only environment debugger surfaces runtime env, storage access, and Supabase configuration health for faster troubleshooting.【F:src/components/EnvironmentDebug.tsx†L1-L63】
+
+## Local development
+1. **Install prerequisites**
+   - Node.js 18+
+   - Yarn 4 (Berry) – this repository already pins `yarn@4.9.4` in `.yarnrc.yml` and `package.json`.
+2. **Install dependencies**
+   ```bash
+   yarn install
+   ```
+3. **Configure environment variables**
+   - Duplicate `.env.local` and populate with your Supabase project keys using the `VITE_` prefixes.
+   - Update `wrangler.toml` with matching `SUPABASE_URL` and `SUPABASE_ANON_KEY` values for Cloudflare Pages deployments.【F:src/integrations/supabase/client.ts†L210-L266】【F:wrangler.toml†L1-L10】
+4. **Start the dev server**
+   ```bash
+   yarn dev
+   ```
+   Visit http://localhost:5173 and use the language toggle in the header components (see `RootLayout`) to switch between Bangla and English copy.
+
+## Quality checks
+- **Linting** – runs ESLint across the entire codebase with the Vite + React + TypeScript configuration.
+  ```bash
+  yarn lint
+  ```
+- **Type checking** – Vite and the TypeScript compiler run automatically during builds; use `yarn build` locally to validate production bundles.
 
 ## Deployment
+- **Static assets** – `yarn build` outputs to `dist/` with all routes ready for Cloudflare Pages hosting.
+- **Cloudflare Pages** – `wrangler pages deploy dist` ships the latest build, injecting Supabase environment variables via Pages Functions middleware.【F:package.json†L7-L13】【F:functions/_middleware.ts†L1-L62】
+- **Supabase Edge Function** – deploy `send-contact-email` through `supabase functions deploy send-contact-email --no-verify-jwt` after setting `RESEND_API_KEY`, `SUPABASE_URL`, and `SUPABASE_ANON_KEY` secrets.【F:supabase/functions/send-contact-email/index.ts†L1-L183】
 
-The site is deployed on Cloudflare for fast global delivery.
-
-## Getting Started
-
-### Prerequisites
-
-- [Node.js](https://nodejs.org/) 18+
-- [yarn v4](https://yarnpkg.com/migration/guide#update-your-configuration-to-the-new-settings)
-
-### Installation
-
-```bash
-git clone <repo-url>
-cd prompt-panda-bangla
-yarn install
+## Project structure
+```
+├── src/
+│   ├── components/       # Hero, cookie consent, performance & security wrappers
+│   ├── contexts/         # Bilingual language provider
+│   ├── hooks/            # Analytics batching and tracking
+│   ├── integrations/     # Supabase client & generated types
+│   └── pages/            # Route-level experiences for marketplace, pricing, support
+├── supabase/
+│   ├── functions/        # Edge functions (Resend-powered contact form)
+│   └── migrations/       # SQL migrations for marketplace, pricing, analytics
+├── functions/            # Cloudflare Pages middleware to expose env vars
+├── public/               # Static assets and service worker shell
+└── wrangler.toml         # Cloudflare Pages project configuration
 ```
 
-### Development server
-
-```bash
-yarn dev
-```
-
-The site will be available at `http://localhost:5173`.
-
-### Linting
-
-```bash
-yarn lint
-```
-
-### Production build
-
-```bash
-yarn build
-```
-
-## Supabase & Email Setup
-
-A Supabase project is required for storing newsletter signups, analytics and contact messages. An edge function (`send-contact-email`) uses [Resend](https://resend.com/) to send confirmation emails. Set the following environment variables when deploying the function:
-
-- `SUPABASE_URL`
-- `SUPABASE_ANON_KEY`
-- `RESEND_API_KEY`
-
-
-## Project Structure
-
-```
-src/
-  components/      # UI, ads and popups
-  hooks/           # Analytics and other custom hooks
-  integrations/    # Supabase client and types
-  pages/           # React router pages
-supabase/
-  functions/       # Edge functions
-  migrations/      # Database schema
-```
-
-## Contact
-
-For collaboration or commercial inquiries, reach out at **md.abir1203@gmail.com**.
-
-Built from Bangladesh 🇧🇩 for the world.
+## Community & support
+For partnerships, press, or enterprise pilots email **md.abir1203@gmail.com**. Built from Bangladesh 🇧🇩 to celebrate Bangla prompt engineering at global scale.

--- a/README_PITCH.md
+++ b/README_PITCH.md
@@ -1,0 +1,46 @@
+# Prompt Bangla AI – Pitch Deck Narrative
+
+This document reframes the repository into investor-ready storytelling beats so you can plug the product directly into a slide deck or founder memo.
+
+## 1. Vision & problem
+- **Vision** – become the top-decile launchpad where Bangladeshi and multilingual creators sell culturally relevant prompts to global teams, with built-in compliance and payouts that compete with Singapore and Dubai marketplaces.【F:src/components/Hero.tsx†L108-L166】
+- **Problem** – global AI prompt marketplaces undervalue Bengali workflows; enterprises struggle to source compliant, localised AI assets quickly; creators lack transparent monetisation and licensing dashboards.【F:src/components/Hero.tsx†L6-L166】
+
+## 2. Solution snapshot
+- **Creator storefront toolkit** – upload prompt bundles, manage licensing, surface preview outputs, and access 72-hour payout pipelines from day one.【F:src/components/Hero.tsx†L6-L108】
+- **Enterprise localisation suite** – compliance vaults, multilingual catalogues, and Supabase-managed pricing toggles make procurement-ready packages a content management update rather than an engineering sprint.【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L139】
+- **Live bidding exchange** – verified buyers broadcast liquidity signals, while sellers respond with offers inside a React-powered exchange front end.【F:src/components/Hero.tsx†L25-L108】
+
+## 3. Product pillars
+1. **Marketplace discovery** – bilingual navigation funnels users to marketplace, exchange, creator hub, enterprise, pricing, and insights destinations.【F:src/pages/Index.tsx†L11-L92】
+2. **Growth loops** – lazy-loaded newsletter and Medium subscription popups monetise later-session attention without harming core vitals.【F:src/App.tsx†L13-L87】【F:src/components/LazyComponents.tsx†L9-L26】
+3. **Compliance & trust** – security headers, GDPR consent, and Supabase rate-limited contact flows showcase enterprise readiness.【F:src/components/SecurityHeaders.tsx†L1-L71】【F:src/components/CookieConsent.tsx†L1-L104】【F:supabase/functions/send-contact-email/index.ts†L1-L183】
+4. **Data advantage** – batched analytics capture scroll depth, time-on-page, and session metrics into Supabase for revenue intelligence and creator reporting.【F:src/hooks/useAnalytics.ts†L1-L189】
+
+## 4. Traction & social proof
+- **Marketplace scale** – 42K+ curated prompts, 70+ countries activated, 300+ enterprise teams referenced directly in the hero narrative to prime social proof.【F:src/components/Hero.tsx†L6-L108】
+- **Revenue potential** – 11% verified buyer conversion and 28% average earnings uplift goals are codified as part of the product story, signalling aggressive yet data-aware KPIs.【F:src/components/Hero.tsx†L108-L166】
+
+## 5. Business model
+- **Primary** – commission on marketplace prompt sales with configurable royalty splits (default 20% platform commission) and tracked payouts via Supabase tables and stored procedures.【F:supabase/migrations/20250720093000-add-marketplace-prompts.sql†L1-L141】
+- **Secondary** – ad monetisation through Google AdSense, Adsterra, and newsletter sponsorships layered on top of the core marketplace experience.【F:src/App.tsx†L1-L87】【F:src/components/PerformanceOptimizer.tsx†L1-L83】
+- **Tertiary** – enterprise localisation retainers with Supabase-managed pricing content, unlocking annual contracts and co-marketing launches.【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L139】
+
+## 6. Why now
+- **Performance moat** – code splitting, service worker caching, and resource hints cut initial load to <2.5s and keep Core Web Vitals in the “good” band for 1,000+ concurrent users.【F:SCALING_SUMMARY.md†L9-L49】
+- **Edge-native readiness** – Cloudflare Pages middleware streams secrets at runtime, while Supabase clients auto-detect edge vs. browser contexts, giving us distribution-ready infrastructure.【F:functions/_middleware.ts†L1-L62】【F:src/integrations/supabase/client.ts†L1-L266】
+
+## 7. Go-to-market
+- **Creator acquisition** – open-source onboarding, weekly office hours, and bilingual support emphasised in the hero CTA drive first creators to publish storefronts.【F:src/components/Hero.tsx†L77-L119】
+- **Enterprise pipeline** – pricing toggles and compliance storytelling give sales teams ready-to-send collateral; contact form edge function logs and emails inbound enterprise leads securely.【F:supabase/migrations/20250721090000-pricing-transparency.sql†L1-L139】【F:supabase/functions/send-contact-email/index.ts†L1-L183】
+- **Community flywheel** – insights and research downloads build top-of-funnel credibility while newsletter popups convert readers into marketplace participants.【F:src/pages/Index.tsx†L11-L92】【F:src/components/LazyComponents.tsx†L9-L26】
+
+## 8. Competitive moat
+- **Cultural datasets** – plans to co-create evaluation datasets and multilingual catalogues are baked into the hero storytelling, signalling proprietary content assets.【F:src/components/Hero.tsx†L108-L166】
+- **Security & governance** – layered CSP, RLS, and rate limiting demonstrate enterprise-calibre guardrails rarely seen in early prompt marketplaces.【F:src/components/SecurityHeaders.tsx†L1-L71】【F:supabase/migrations/20250720093000-add-marketplace-prompts.sql†L1-L141】【F:supabase/functions/send-contact-email/index.ts†L1-L183】
+
+## 9. Ask & next steps
+- **Capital/partners sought** – looking for collaborators ready to scale Bengali prompt engineering internationally; contact **md.abir1203@gmail.com** for enterprise pilots or investment conversations.
+- **Immediate roadmap** – configure Supabase connection pooling, activate CDN, and launch real-time monitoring dashboards to sustain the 1,000+ concurrency target outlined in the scaling plan.【F:SCALING_SUMMARY.md†L51-L68】
+
+Use these talking points as slide titles, bullet copy, or speaker notes to accelerate fundraising and partnership pitches without reverse-engineering the codebase.


### PR DESCRIPTION
## Summary
- expand the main README with architecture, Supabase, deployment, and operations guidance for Prompt Bangla AI
- add a pitch-deck-aligned README_PITCH.md that turns the product into investor-ready talking points

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68cde99bf9148326884cab3bea90757f