### PR TITLE
[PromptBazaarAI] Fix Supabase env injection and CSP

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -31,7 +31,7 @@ const createRuntimeEnvScript = (env: EnvRecord): string | null => {
 
   const json = JSON.stringify(payload).replace(/</g, "\\u003c");
 
-  return `(() => {\n  const existing = typeof window !== "undefined" && window.__ENV__ ? window.__ENV__ : {};\n  const update = Object.assign({}, ${json});\n  const nextEnv = { ...existing, ...update };\n\n  if (typeof window !== "undefined") {\n    window.__ENV__ = nextEnv;\n  }\n\n  try {\n    // eslint-disable-next-line @typescript-eslint/no-explicit-any\n    (globalThis as any).__ENV__ = nextEnv;\n  } catch (_) {\n    // Swallow errors when assigning to immutable globals.\n  }\n})();`;
+  return `(() => {\n  const existing = typeof window !== "undefined" && window.__ENV__ ? window.__ENV__ : {};\n  const update = Object.assign({}, ${json});\n  const nextEnv = { ...existing, ...update };\n\n  if (typeof window !== "undefined") {\n    window.__ENV__ = nextEnv;\n  }\n\n  try {\n    if (typeof globalThis !== "undefined") {\n      globalThis.__ENV__ = nextEnv;\n    }\n  } catch (_) {\n    // Swallow errors when assigning to immutable globals.\n  }\n})();`;
 };
 
 export const onRequest = async (context: MiddlewareContext): Promise<Response> => {

--- a/src/components/SecurityHeaders.tsx
+++ b/src/components/SecurityHeaders.tsx
@@ -48,6 +48,7 @@ const SecurityHeaders: React.FC = () => {
             https://realsrv.com
             https://inklinkor.com
             https://www.topcreativeformat.com
+            https://mnqkeoeikfjwlgyowsnb.supabase.co
             https://medium.com
             https://api.medium.com;
           frame-src 'self'
@@ -58,6 +59,7 @@ const SecurityHeaders: React.FC = () => {
             https://syndication.realsrv.com
             https://realsrv.com
             https://www.topcreativeformat.com;
+          frame-ancestors 'self';
           object-src 'none';
           base-uri 'self';
           form-action 'self' https://medium.com;
@@ -70,9 +72,6 @@ const SecurityHeaders: React.FC = () => {
       
       {/* Prevent content type sniffing */}
       <meta httpEquiv="X-Content-Type-Options" content="nosniff" />
-      
-      {/* Prevent clickjacking */}
-      <meta httpEquiv="X-Frame-Options" content="SAMEORIGIN" />
       
       {/* Referrer Policy - Controls referrer information */}
       <meta name="referrer" content="strict-origin-when-cross-origin" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,37 +1,47 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 
 // https://vitejs.dev/config/
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development'
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const supabaseUrl = env.SUPABASE_URL ?? env.VITE_SUPABASE_URL ?? "";
+  const supabaseAnonKey = env.SUPABASE_ANON_KEY ?? env.VITE_SUPABASE_ANON_KEY ?? "";
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks(id) {
-          if (id.includes("node_modules")) {
-            // Keeping React in the default vendor chunk avoids circular
-            // imports between custom chunks that caused React to be
-            // undefined during runtime. This prevents "createContext" errors
-            // in the production bundle.
-            if (id.includes("radix-ui")) return "radix-ui";
-            if (id.includes("@tanstack")) return "tanstack";
-            return "vendor";
-          }
+    plugins: [
+      react(),
+      mode === 'development'
+    ].filter(Boolean),
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
+    },
+    define: {
+      "import.meta.env.SUPABASE_URL": JSON.stringify(supabaseUrl),
+      "import.meta.env.SUPABASE_ANON_KEY": JSON.stringify(supabaseAnonKey),
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes("node_modules")) {
+              // Keeping React in the default vendor chunk avoids circular
+              // imports between custom chunks that caused React to be
+              // undefined during runtime. This prevents "createContext" errors
+              // in the production bundle.
+              if (id.includes("radix-ui")) return "radix-ui";
+              if (id.includes("@tanstack")) return "tanstack";
+              return "vendor";
+            }
+          },
         },
       },
     },
-  },
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- remove the TypeScript-only assertion from the runtime env injection snippet so it executes as valid JavaScript in the browser
- expose Supabase URL and anon key to the client build via Vite so the resolver stops logging missing env errors
- extend the CSP to allow Supabase traffic, rely on frame-ancestors for clickjacking defense, and drop the invalid X-Frame-Options meta

## Testing
- yarn lint
- yarn test *(fails: script not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68d473f2d41883268ce0723f800259f1